### PR TITLE
Extra config block for Large Maps

### DIFF
--- a/Build/Compilers/Nodebuilders/zdbsp.cfg
+++ b/Build/Compilers/Nodebuilders/zdbsp.cfg
@@ -65,4 +65,11 @@ nodebuilders
 		compiler = "zdbsp";
 		parameters = "-z -X -o%FO %FI";
 	}
+	
+	zdbsp_udmf_compressed_huge
+	{
+		title = "ZDBSP - Compress nodes (UDMF) (Large Maps)";
+		compiler = "zdbsp";
+		parameters = "-z -X -s016 -p128 -d032 -G -5 -o%FO %FI";
+	}
 }


### PR DESCRIPTION
This extra block helps ZDBSP building better nodes for maps that are too big and starts generating visual issues with regular nodebuilding.