### PR TITLE
Fix directory separators

### DIFF
--- a/Source/Core/ZDoom/DecorateParser.cs
+++ b/Source/Core/ZDoom/DecorateParser.cs
@@ -231,7 +231,7 @@ namespace CodeImp.DoomBuilder.ZDoom
 							}
 
 							//mxd. Backward slashes are not supported
-							if(filename.Contains(Path.DirectorySeparatorChar.ToString(CultureInfo.InvariantCulture)))
+							if(filename.Contains("\\"))
 							{
 								ReportError("Only forward slashes are supported by ZDoom");
 								return false;

--- a/Source/Core/ZDoom/GldefsParser.cs
+++ b/Source/Core/ZDoom/GldefsParser.cs
@@ -805,7 +805,7 @@ namespace CodeImp.DoomBuilder.ZDoom
 			}
 
 			// Backward slashes are not supported
-			if(includelump.Contains(Path.DirectorySeparatorChar.ToString(CultureInfo.InvariantCulture)))
+			if(includelump.Contains("\\"))
 			{
 				ReportError("Only forward slashes are supported by GZDoom");
 				return false;

--- a/Source/Core/ZDoom/MapinfoParser.cs
+++ b/Source/Core/ZDoom/MapinfoParser.cs
@@ -227,7 +227,7 @@ namespace CodeImp.DoomBuilder.ZDoom
 				}
 
 				// Backward slashes are not supported
-				if(includelump.Contains(Path.DirectorySeparatorChar.ToString(CultureInfo.InvariantCulture)))
+				if(includelump.Contains("\\"))
 				{
 					ReportError("Only forward slashes are supported by ZDoom");
 					return false;

--- a/Source/Core/ZDoom/ModeldefParser.cs
+++ b/Source/Core/ZDoom/ModeldefParser.cs
@@ -114,7 +114,7 @@ namespace CodeImp.DoomBuilder.ZDoom
                         }
 
                         //mxd. Backward slashes are not supported
-                        if (filename.Contains(Path.DirectorySeparatorChar.ToString(CultureInfo.InvariantCulture)))
+                        if (filename.Contains("\\"))
                         {
                             ReportError("Only forward slashes are supported by ZDoom");
                             return false;

--- a/Source/Core/ZDoom/ZScriptParser.cs
+++ b/Source/Core/ZDoom/ZScriptParser.cs
@@ -273,7 +273,7 @@ namespace CodeImp.DoomBuilder.ZDoom
             }
 
             //mxd. Backward slashes are not supported
-            if (filename.Contains(Path.DirectorySeparatorChar.ToString(CultureInfo.InvariantCulture)))
+            if (filename.Contains("\\"))
             {
                 ReportError("Only forward slashes are supported by ZDoom");
                 return false;


### PR DESCRIPTION
Path.DirectorySeparatorChar is a forward slash on Linux/Unix, so it ended up preventing DECORATE and ZSCRIPT code from being loaded on Linux.