### PR TITLE
Attempt to improve Unix filesystem support

### DIFF
--- a/Source/Core/Data/DirectoryReader.cs
+++ b/Source/Core/Data/DirectoryReader.cs
@@ -468,6 +468,7 @@ namespace CodeImp.DoomBuilder.Data
 		{
 			MemoryStream s = null;
 			string casecorrectfilename = GetCorrectCaseForFile(filename);
+
 			try
 			{
 				lock(this)
@@ -514,6 +515,11 @@ namespace CodeImp.DoomBuilder.Data
 			return tempfile;
 		}
 
+		/// <summary>
+		/// Returns the correctly cased file from a path/file. This is required for case sensitive file systems.
+		/// </summary>
+		/// <param name="filepathname">File name get the the correctly cased name from</param>
+		/// <returns></returns>
 		protected override string GetCorrectCaseForFile(string filepathname)
 		{
 			return files.GetFileInfo(filepathname).filepathname;

--- a/Source/Core/Data/DirectoryReader.cs
+++ b/Source/Core/Data/DirectoryReader.cs
@@ -467,12 +467,12 @@ namespace CodeImp.DoomBuilder.Data
 		internal override MemoryStream LoadFile(string filename)
 		{
 			MemoryStream s = null;
-
-			try 
+			string casecorrectfilename = GetCorrectCaseForFile(filename);
+			try
 			{
 				lock(this)
 				{
-					s = new MemoryStream(File.ReadAllBytes(Path.Combine(location.location, filename)));
+					s = new MemoryStream(File.ReadAllBytes(Path.Combine(location.location, casecorrectfilename)));
 				}
 			} 
 			catch(Exception e) 
@@ -512,6 +512,11 @@ namespace CodeImp.DoomBuilder.Data
 			string tempfile = General.MakeTempFilename(General.Map.TempPath, "wad");
 			File.Copy(Path.Combine(location.location, filename), tempfile);
 			return tempfile;
+		}
+
+		protected override string GetCorrectCaseForFile(string filepathname)
+		{
+			return files.GetFileInfo(filepathname).filepathname;
 		}
 
 		#endregion

--- a/Source/Core/Data/PK3StructuredReader.cs
+++ b/Source/Core/Data/PK3StructuredReader.cs
@@ -741,23 +741,26 @@ namespace CodeImp.DoomBuilder.Data
 			return images;
 		}
 
+		/// <summary>
+		/// Gets a correctly cased file from a path/file. This is required for case sensitive file systems.
+		/// </summary>
+		/// <param name="filename">File name without path</param>
+		/// <param name="pathname">Path to the file</param>
+		/// <param name="type">Type of file (i.e. everything before the first dot)</param>
+		/// <returns>Array with one element on success, array with no elements on failure</returns>
 		protected string[] GetFileAtPath(string filename, string pathname, string type)
 		{
-			string[] allfilenames;
 			string fullname = Path.Combine(pathname, filename);
+
 			if (FileExists(fullname))
 			{
-				allfilenames = new string[1];
-				allfilenames[0] = Path.Combine(pathname, filename);
-				allfilenames[0] = GetCorrectCaseForFile(allfilenames[0]);
+				return new string[1] { GetCorrectCaseForFile(fullname) };
 			}
 			else
 			{
-				allfilenames = new string[0];
 				General.ErrorLogger.Add(ErrorType.Warning, "Unable to load " + type + " file \"" + fullname + "\"");
+				return new string[0];
 			}
-
-			return allfilenames;
 		}
 
 		// This copies images from a collection unless they already exist in the list
@@ -823,7 +826,11 @@ namespace CodeImp.DoomBuilder.Data
 			}
 		}
 
-		// Unix-like systems have case-sensitive filesystems. Use this to correct the case of a filename with the given path.
+		/// <summary>
+		/// Returns the correctly cased file from a path/file. This is required for case sensitive file systems. For PK3s the input will already have the correct case.
+		/// </summary>
+		/// <param name="filepathname">File name get the the correctly cased name from</param>
+		/// <returns></returns>
 		protected virtual string GetCorrectCaseForFile(string filepathname)
 		{
 			return filepathname;

--- a/Source/Core/Data/PK3StructuredReader.cs
+++ b/Source/Core/Data/PK3StructuredReader.cs
@@ -501,17 +501,7 @@ namespace CodeImp.DoomBuilder.Data
 			
 			if(filename.IndexOf('.') > -1)
 			{
-				string fullname = Path.Combine(pathname, filename);
-				if(FileExists(fullname)) 
-				{
-					allfilenames = new string[1];
-					allfilenames[0] = Path.Combine(pathname, filename);
-				} 
-				else 
-				{
-					allfilenames = new string[0];
-					General.ErrorLogger.Add(ErrorType.Warning, "Unable to load DECORATE file \"" + fullname + "\"");
-				}
+                allfilenames = GetFileAtPath(filename, pathname, "DECORATE");
 			}
 			else
 				allfilenames = GetAllFilesWithTitle(pathname, filename, false);
@@ -545,17 +535,7 @@ namespace CodeImp.DoomBuilder.Data
 
             if (filename.IndexOf('.') > -1)
             {
-                string fullname = Path.Combine(pathname, filename);
-                if (FileExists(fullname))
-                {
-                    allfilenames = new string[1];
-                    allfilenames[0] = Path.Combine(pathname, filename);
-                }
-                else
-                {
-                    allfilenames = new string[0];
-                    General.ErrorLogger.Add(ErrorType.Warning, "Unable to load ZSCRIPT file \"" + fullname + "\"");
-                }
+                allfilenames = GetFileAtPath(filename, pathname, "ZSCRIPT");
             }
             else
                 allfilenames = GetAllFilesWithTitle(pathname, filename, false);
@@ -589,17 +569,7 @@ namespace CodeImp.DoomBuilder.Data
 
             if (filename.IndexOf('.') > -1)
             {
-                string fullname = Path.Combine(pathname, filename);
-                if (FileExists(fullname))
-                {
-                    allfilenames = new string[1];
-                    allfilenames[0] = Path.Combine(pathname, filename);
-                }
-                else
-                {
-                    allfilenames = new string[0];
-                    General.ErrorLogger.Add(ErrorType.Warning, "Unable to load MODELDEF file \"" + fullname + "\"");
-                }
+                allfilenames = GetFileAtPath(filename, pathname, "MODELDEF");
             }
             else
                 allfilenames = GetAllFilesWithTitle(pathname, filename, false);
@@ -770,7 +740,26 @@ namespace CodeImp.DoomBuilder.Data
 			// Return result
 			return images;
 		}
-		
+
+		protected string[] GetFileAtPath(string filename, string pathname, string type)
+		{
+			string[] allfilenames;
+			string fullname = Path.Combine(pathname, filename);
+			if (FileExists(fullname))
+			{
+				allfilenames = new string[1];
+				allfilenames[0] = Path.Combine(pathname, filename);
+				allfilenames[0] = GetCorrectCaseForFile(allfilenames[0]);
+			}
+			else
+			{
+				allfilenames = new string[0];
+				General.ErrorLogger.Add(ErrorType.Warning, "Unable to load " + type + " file \"" + fullname + "\"");
+			}
+
+			return allfilenames;
+		}
+
 		// This copies images from a collection unless they already exist in the list
 		private static void AddImagesToList(Dictionary<long, ImageData> targetlist, IEnumerable<ImageData> sourcelist)
 		{
@@ -832,6 +821,12 @@ namespace CodeImp.DoomBuilder.Data
 				// Path is already relative
 				return anypath;
 			}
+		}
+
+		// Unix-like systems have case-sensitive filesystems. Use this to correct the case of a filename with the given path.
+		protected virtual string GetCorrectCaseForFile(string filepathname)
+		{
+			return filepathname;
 		}
 
 		//mxd. Archives and Folders don't have lump indices

--- a/Source/Core/Data/PK3StructuredReader.cs
+++ b/Source/Core/Data/PK3StructuredReader.cs
@@ -754,7 +754,7 @@ namespace CodeImp.DoomBuilder.Data
 
 			if (FileExists(fullname))
 			{
-				return new string[1] { GetCorrectCaseForFile(fullname) };
+				return new string[1] { fullname };
 			}
 			else
 			{

--- a/Source/Core/IO/DirectoryFilesList.cs
+++ b/Source/Core/IO/DirectoryFilesList.cs
@@ -77,7 +77,7 @@ namespace CodeImp.DoomBuilder.IO
 				}
 				if(skipfolder) continue;
 
-				entries.Add(e.filepathname, e);
+				AddOrReplaceEntry(e);
 			}
 		}
 
@@ -113,13 +113,38 @@ namespace CodeImp.DoomBuilder.IO
 					continue;
 				}
 
-				entries.Add(e.filepathname, e);
+				AddOrReplaceEntry(e);
 			}
 		}
 
 		#endregion
 
 		#region ================== Methods
+
+		// This checks whether a file is in the entry dictionary, adds it if it
+		// isn't, and replaces the existing entry if the new entry is lowercase
+		private void AddOrReplaceEntry(DirectoryFileEntry e)
+		{
+			// If the entry is already in the dictionary, add the one with
+			// greater ordinal value (prefer lowercase)
+			if(entries.ContainsKey(e.filepathname))
+			{
+				// Get the key for the existing entry. It may have a
+				// different case, since the dictionary is set up to be
+				// case insensitive.
+				string existingEntryPath = entries[e.filepathname].filepathname;
+				if(e.filepathname.CompareTo(existingEntryPath) == -1)
+				{
+					entries.Remove(e.filepathname);
+					entries.Add(e.filepathname, e);
+				}
+			}
+			else
+			{
+				// Just add the entry, since it's not in the dictionary yet.
+				entries.Add(e.filepathname, e);
+			}
+		}
 
 		// This checks if a given file exists
 		// The given file path must not be absolute

--- a/Source/Core/ZDoom/ModeldefStructure.cs
+++ b/Source/Core/ZDoom/ModeldefStructure.cs
@@ -102,7 +102,7 @@ namespace CodeImp.DoomBuilder.ZDoom
 				{
 					case "path":
 						parser.SkipWhitespace(true);
-						path = parser.StripTokenQuotes(parser.ReadToken(false)).Replace("/", "\\"); // Don't skip newline
+						path = parser.StripTokenQuotes(parser.ReadToken(false)).Replace("\\", "/"); // Don't skip newline
 						if(string.IsNullOrEmpty(path))
 						{
 							parser.ReportError("Expected model path");


### PR DESCRIPTION
Add some new methods to PK3StructuredReader and DirectoryReader, which get the filename with the correct case, and get a file at a particular path.
Replace backslashes in modeldef model paths with forward slashes, instead of doing the opposite, which was preventing some models from loading.

I don't know whether or not this is a good solution or not, since I don't know the UDB codebase very well.