### PR TITLE
Remove Visual Studio solution retargeting from CI config

### DIFF
--- a/.github/workflows/continuous_integration_windows.yml
+++ b/.github/workflows/continuous_integration_windows.yml
@@ -22,8 +22,6 @@ jobs:
         $options = @( `
           '-property:Configuration=${{ matrix.configuration }}', `
           '-property:Platform=${{ matrix.platform }}', `
-          '-property:WindowsTargetPlatformVersion=10.0', `
-          '-property:PlatformToolset=v142', `
           '-maxcpucount', `
           '-verbosity:minimal' `
         )


### PR DESCRIPTION
Since 7af52a9bf76c960753428450f55cbff6ddc08253, VS2019 is supported out of the box.