### PR TITLE
Fix compilation error of Windows targets

### DIFF
--- a/Source/Core/General/General.cs
+++ b/Source/Core/General/General.cs
@@ -67,7 +67,7 @@ namespace CodeImp.DoomBuilder
 		}
 #else
 		public static void ApplyMonoListViewFix(System.Windows.Forms.ListView listview) {}
-		public static void ApplyDataGridViewFix(System.Windows.Form.DataGridView gridview) {}
+		public static void ApplyDataGridViewFix(System.Windows.Forms.DataGridView gridview) {}
 #endif
 
 #if NO_WIN32


### PR DESCRIPTION
General\General.cs(70,58): error CS0234: The type or namespace name 'Form' does not exist in the namespace 'System.Windows' (are you missing an assembly reference?)