### PR TITLE
Report build error in corresponding CI job

### DIFF
--- a/.github/workflows/continuous_integration_windows.yml
+++ b/.github/workflows/continuous_integration_windows.yml
@@ -26,7 +26,9 @@ jobs:
           '-verbosity:minimal' `
         )
         & $msbuild Builder.sln $options
+        if (-not $?) { throw "Build failed" }
         & $msbuild Source\Tools\Updater\Updater.csproj $options
+        if (-not $?) { throw "Build failed" }
 
     - name: Test Files Presence
       run: |


### PR DESCRIPTION
Without explicit check for msbuild return code 'Test Files Presence' was marked as failed job