### PR TITLE
Fixes for Linux/Mono WinForms

### DIFF
--- a/Source/Core/VisualModes/VisualThing.cs
+++ b/Source/Core/VisualModes/VisualThing.cs
@@ -104,7 +104,17 @@ namespace CodeImp.DoomBuilder.VisualModes
 		
 		#region ================== Properties
 		
-		internal VertexBuffer GeometryBuffer { get { return geobuffers[spriteframe]; } }
+		internal VertexBuffer GeometryBuffer { get {
+				if (geobuffers != null)
+				{
+					return geobuffers[spriteframe];
+				}
+				else
+				{
+					return null;
+				}
+			}
+		}
 		internal VertexBuffer CageBuffer { get { return cagebuffer; } } //mxd
 		internal int CageLength { get { return cagelength; } } //mxd
 		internal bool NeedsUpdateGeo { get { return updategeo; } }

--- a/Source/Plugins/BuilderEffects/BuilderEffectsMono.csproj
+++ b/Source/Plugins/BuilderEffects/BuilderEffectsMono.csproj
@@ -39,7 +39,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\..\Build\Plugins\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;MONO_WINFORMS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
@@ -49,7 +49,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\..\Build\Plugins\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;MONO_WINFORMS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
@@ -60,7 +60,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug + Profiler|x86' ">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>..\..\..\Build\Plugins\</OutputPath>
-    <DefineConstants>DEBUG;TRACE;PROFILE</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;PROFILE;MONO_WINFORMS</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>x86</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
@@ -74,12 +74,13 @@
     <PlatformTarget>x86</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>false</Prefer32Bit>
+    <DefineConstants>MONO_WINFORMS</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <PlatformTarget>x64</PlatformTarget>
     <OutputPath>..\..\..\Build\Plugins\</OutputPath>
     <Prefer32Bit>false</Prefer32Bit>
-    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;MONO_WINFORMS</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <PlatformTarget>x64</PlatformTarget>
@@ -87,13 +88,13 @@
     <Prefer32Bit>false</Prefer32Bit>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Optimize>false</Optimize>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;MONO_WINFORMS</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug + Profiler|x64'">
     <PlatformTarget>x64</PlatformTarget>
     <OutputPath>..\..\..\Build\Plugins\</OutputPath>
     <Prefer32Bit>false</Prefer32Bit>
-    <DefineConstants>TRACE;DEBUG;PROFILE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;PROFILE;MONO_WINFORMS</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release + Profiler|x64'">
     <PlatformTarget>x64</PlatformTarget>
@@ -101,6 +102,7 @@
     <Prefer32Bit>false</Prefer32Bit>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Optimize>true</Optimize>
+    <DefineConstants>MONO_WINFORMS</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Source/Plugins/BuilderEffects/Controls/IntControl.designer.cs
+++ b/Source/Plugins/BuilderEffects/Controls/IntControl.designer.cs
@@ -29,7 +29,11 @@
 		{
 			this.trackBar1 = new System.Windows.Forms.TrackBar();
 			this.label1 = new System.Windows.Forms.Label();
+			#if !MONO_WINFORMS
 			this.numericUpDown1 = new CodeImp.DoomBuilder.BuilderEffects.NumericUpDownEx();
+			#else
+			this.numericUpDown1 = new System.Windows.Forms.NumericUpDown();
+			#endif
 			this.labelMaximum = new System.Windows.Forms.Label();
 			((System.ComponentModel.ISupportInitialize)(this.trackBar1)).BeginInit();
 			((System.ComponentModel.ISupportInitialize)(this.numericUpDown1)).BeginInit();
@@ -99,7 +103,11 @@
 
 		private System.Windows.Forms.TrackBar trackBar1;
 		private System.Windows.Forms.Label label1;
+		#if !MONO_WINFORMS
 		private NumericUpDownEx numericUpDown1;
+		#else
+		private System.Windows.Forms.NumericUpDown numericUpDown1;
+		#endif
 		private System.Windows.Forms.Label labelMaximum;
 	}
 }

--- a/Source/Plugins/BuilderEffects/Controls/IntControl.designer.cs
+++ b/Source/Plugins/BuilderEffects/Controls/IntControl.designer.cs
@@ -33,6 +33,10 @@
 			this.numericUpDown1 = new CodeImp.DoomBuilder.BuilderEffects.NumericUpDownEx();
 			#else
 			this.numericUpDown1 = new System.Windows.Forms.NumericUpDown();
+			this.numericUpDown1.MouseWheel += (object sender, System.Windows.Forms.MouseEventArgs e) => {
+				System.Windows.Forms.NumericUpDown control = (System.Windows.Forms.NumericUpDown) sender;
+				control.Value += e.Delta;
+			};
 			#endif
 			this.labelMaximum = new System.Windows.Forms.Label();
 			((System.ComponentModel.ISupportInitialize)(this.trackBar1)).BeginInit();


### PR DESCRIPTION
- Use NumericUpDown instead of NumericUpDownEx on Mono WinForms (allows "Apply Directional Lighting" to be used on Linux, although only by using the Ctrl-L hotkey)
- Check whether VisualThing.geobuffers is null before trying to index it with the GeometryBuffer property, so that UDB doesn't try to index a null pointer.