### PR TITLE
Allow build type to be set in the environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 
+BUILDTYPE ?= Release
+
 all: linux
 
 run:
@@ -9,7 +11,7 @@ linux: builder native
 mac: builder nativemac
 
 builder:
-	msbuild /nologo /verbosity:minimal -p:Configuration=Release BuilderMono.sln
+	msbuild /nologo /verbosity:minimal -p:Configuration=$(BUILDTYPE) BuilderMono.sln
 	cp builder.sh Build/builder
 	chmod +x Build/builder
 


### PR DESCRIPTION
This allows for release or debug configurations, for those who prefer typing "make" into the terminal.