### PR TITLE
Skip implicit save of SCRIPTS lump when the text editor is unchanged

### DIFF
--- a/Source/Core/Controls/Scripting/ScriptLumpDocumentTab.cs
+++ b/Source/Core/Controls/Scripting/ScriptLumpDocumentTab.cs
@@ -73,6 +73,7 @@ namespace CodeImp.DoomBuilder.Controls
 			{
 				editor.SetText(stream.ToArray()); //mxd
 				editor.ClearUndoRedo();
+				editor.SetSavePoint();
 			}
 
 			// Set title
@@ -108,6 +109,8 @@ namespace CodeImp.DoomBuilder.Controls
 		// Implicit save
 		public override bool Save()
 		{
+			if (!editor.IsChanged) return false;
+
             // [ZZ] remove trailing whitespace
             RemoveTrailingWhitespace();
 

--- a/Source/Core/Controls/Scripting/ScriptResourceDocumentTab.cs
+++ b/Source/Core/Controls/Scripting/ScriptResourceDocumentTab.cs
@@ -48,6 +48,7 @@ namespace CodeImp.DoomBuilder.Controls
 				editor.SetText(stream.ToArray());
 				editor.Scintilla.ReadOnly = source.IsReadOnly;
 				editor.ClearUndoRedo();
+				editor.SetSavePoint();
 			}
 			else
 			{
@@ -92,7 +93,7 @@ namespace CodeImp.DoomBuilder.Controls
 		// Return true when successfully saved
 		public override bool Save()
 		{
-			if(source.IsReadOnly) return false;
+			if(source.IsReadOnly || !editor.IsChanged) return false;
 
             // [ZZ] remove trailing whitespace
             RemoveTrailingWhitespace();


### PR DESCRIPTION
Following https://github.com/jewalky/UltimateDoomBuilder/commit/95f5c719b7c104de72455bde4e5e2a92e6f53b18, also fix the script editor sometimes falsely marking the map as modified.

Examples:

1.  * Start a new ZDoom map
     * Open script editor
     * Close script editor

     UDB's title header shows the map is modified and closing will prompt to save... nothing.
2. * Open an existing ZDoom map
    * Open script editor
    * Close script editor

    Same result as above.

I've experienced this when just having a look at a script or copying an ACS snippet into another map.

Stop calling `ScriptFileDocumentTab.RemoveTrailingWhitespace()` on a text editor that has unchanged text. This causes the currently-opened map's `isChanged` flag to be `true` when nothing was modified.

`SetSavePoint()` ( https://github.com/jacobslusser/ScintillaNET/blob/master/src/ScintillaNET/Scintilla.cs#L2370 ) must be added after the initial `setText()` call so `ScriptEditorControl.scriptedit.Modified` is `false` immediately after the `SCRIPTS` lump is opened (or a new one is started.)