### PR TITLE
Ignore texture patch negative vertical offset

### DIFF
--- a/Source/Core/Data/TexturePatch.cs
+++ b/Source/Core/Data/TexturePatch.cs
@@ -65,7 +65,7 @@ namespace CodeImp.DoomBuilder.Data
 			// Initialize
 			this.LumpName = lumpname;
 			this.X = x;
-			this.Y = y;
+			this.Y = y < 0 ? 0 : y;
 			this.FlipX = false;
 			this.FlipY = false;
 			this.Rotate = 0;


### PR DESCRIPTION
The first half of this article: https://doomwiki.org/wiki/Vertical_offsets_are_ignored_in_texture_patches

Reference Discord chat from December 2020: https://discord.com/channels/659791526586613770/659795578649313331/785604065262043136

`TEXTUREx` lumps in Doom's IWADs have a negative offset for patches in textures `BIGDOOR7` and `STEP2` which are ignored by the game renderer. Instead it defaults to a y-offset value of 0. I found the `originy` references in the original Doom source but got lost in ZDoom's `TopOffset` texture-scaling abstractions.

https://github.com/id-Software/DOOM/blob/77735c3ff0772609e9c8d29e3ce2ab42ff54d20b/linuxdoom-1.10/r_data.c#L202-L208

3D visual mode in DB2 and its forks have been using that negative offset when vanilla Doom and every source port (including [G]ZDoom) don't support it.

`BIGDOOR7` Before:

![bigdoor7-bug](https://user-images.githubusercontent.com/823566/113764196-a3d29c80-96e8-11eb-8256-a0c44d4f028b.png)

`BIGDOOR7` After:

![bigdoor7-fixed](https://user-images.githubusercontent.com/823566/113764211-a8975080-96e8-11eb-8ec0-5153b3d7d688.png)