### PR TITLE
"Unknown Texture" error checker skips Boom translucency lumps

### DIFF
--- a/Build/Configurations/Includes/Boom_linedefs.cfg
+++ b/Build/Configurations/Includes/Boom_linedefs.cfg
@@ -886,6 +886,11 @@ translucent
 	{
 		title = "Translucent (Middle Texture)";
 		prefix = "";
+		
+		errorchecker
+		{
+			ignoremiddletexture = true;
+		}
 	}
 }
 


### PR DESCRIPTION
I came across this one while revisiting a legacy Boom map, of all things a Mordeth E2 reject by AdamW that I had touched up in 1999. It used a custom translucency lump applied as a midtex.

Boom linedef special 260: https://soulsphere.org/projects/boomref/#ld260

> if this linedef's first sidedef contains a valid lump name for its middle texture (as opposed to a texture name), and the lump is 64K long, then that lump will be used as the translucency filter instead of the default `TRANMAP`

I don't believe the ZDoom-in-Hexen-format version 208 supports this since translucency is a linedef special arg: https://zdoom.org/ref2/specials/translucentline.html

## Should `CheckUnknownTextures.run()` check that a given lump name exists?

For both Boom specials 242 (sector transfer) and 260 (translucency), would it be inexpensive to actually check the given colormap or translucency lump name exists in the loaded resources? Ignoring ZDoom's hardcoded "WATERMAP". e.g., when switching texture WADs, I'd like to know when the colormap wasn't migrated over.

**Edit:** `PK3StructuredReader`'s colormap handling may make this more complicated than its worth.