### PR TITLE
VPO limit configurable for Visplane Explorer

### DIFF
--- a/Build/Configurations/Includes/Doom_common.cfg
+++ b/Build/Configurations/Includes/Doom_common.cfg
@@ -73,7 +73,12 @@ mapformat_doom
   // Generalized actions
   generalizedlinedefs = false;
   generalizedsectors = false;
-  
+
+  staticlimits
+  {
+    visplanes = 128;
+  }
+
   // DEFAULT SECTOR BRIGHTNESS LEVELS
   sectorbrightness
   {

--- a/Build/Configurations/Includes/Heretic_common.cfg
+++ b/Build/Configurations/Includes/Heretic_common.cfg
@@ -27,7 +27,12 @@ mapformat_doom
   // Generalized actions
   generalizedlinedefs = false;
   generalizedsectors = false;
-  
+
+  staticlimits
+  {
+    visplanes = 128;
+  }
+
   // DEFAULT SECTOR BRIGHTNESS LEVELS
   sectorbrightness
   {

--- a/Build/Configurations/Includes/Hexen_common.cfg
+++ b/Build/Configurations/Includes/Hexen_common.cfg
@@ -27,7 +27,12 @@ mapformat_hexen
 	// Generalized actions
 	generalizedlinedefs = false;
 	generalizedsectors = false;
-	
+
+	staticlimits
+	{
+		visplanes = 160;
+	}
+
 	// DEFAULT SECTOR BRIGHTNESS LEVELS
 	sectorbrightness
 	{

--- a/Build/Configurations/Includes/Strife_common.cfg
+++ b/Build/Configurations/Includes/Strife_common.cfg
@@ -27,7 +27,12 @@ mapformat_doom
   // Generalized actions
   generalizedlinedefs = false;
   generalizedsectors = false;
-  
+
+  staticlimits
+  {
+    visplanes = 200;
+  }
+
   // DEFAULT SECTOR BRIGHTNESS LEVELS
   sectorbrightness
   {

--- a/Source/Core/Builder.csproj
+++ b/Source/Core/Builder.csproj
@@ -143,6 +143,7 @@
     <Compile Include="Compilers\AccCompiler.cs" />
     <Compile Include="Compilers\NodesCompiler.cs" />
     <Compile Include="Config\ArgumentInfo.cs" />
+    <Compile Include="Config\StaticLimits.cs" />
     <Compile Include="Config\MapLumpInfo.cs" />
     <Compile Include="Config\ScriptConfiguration.cs" />
     <Compile Include="Config\DefinedTextureSet.cs" />

--- a/Source/Core/BuilderMono.csproj
+++ b/Source/Core/BuilderMono.csproj
@@ -159,6 +159,7 @@
     <Compile Include="Config\LinedefActivateInfo.cs" />
     <Compile Include="Config\ProgramConfiguration.cs" />
     <Compile Include="Config\SkillInfo.cs" />
+    <Compile Include="Config\StaticLimits.cs" />
     <Compile Include="Config\TagType.cs" />
     <Compile Include="Config\TextureSet.cs" />
     <Compile Include="Config\ThingCategory.cs" />

--- a/Source/Core/Config/GameConfiguration.cs
+++ b/Source/Core/Config/GameConfiguration.cs
@@ -108,7 +108,10 @@ namespace CodeImp.DoomBuilder.Config
 		private readonly bool doommapformat;
 		private readonly bool hexenmapformat;
 		private readonly bool universalmapformat;
-		
+
+		// Static limits for the base game and map format.
+		private readonly StaticLimits staticlimits;
+
 		// Texture/flat/voxel sources
 		private readonly IDictionary textureranges;
 		private readonly IDictionary hiresranges; //mxd
@@ -246,6 +249,9 @@ namespace CodeImp.DoomBuilder.Config
 		public bool UDMF { get { return universalmapformat; } }
 		public bool HEXEN { get { return hexenmapformat; } }
 		public bool DOOM { get { return doommapformat; } }
+
+		// Static limits for the base game and map format.
+		public StaticLimits StaticLimits { get { return staticlimits; } }
 
 		public bool UseLocalSidedefTextureOffsets { get { return localsidedeftextureoffsets; } } //MaxW
 		public bool Effect3DFloorSupport { get { return effect3dfloorsupport; } }
@@ -424,6 +430,9 @@ namespace CodeImp.DoomBuilder.Config
 			universalmapformat = (formatinterface == "UniversalMapSetIO");
 			hexenmapformat = (formatinterface == "HexenMapSetIO");
 			doommapformat = (formatinterface == "DoomMapSetIO");
+
+			// Read static limits for the base game and map format.
+			staticlimits = new StaticLimits(cfg);
 
 			//mxd. Texture names length
 			longtexturenames = cfg.ReadSetting("longtexturenames", false);

--- a/Source/Core/Config/StaticLimits.cs
+++ b/Source/Core/Config/StaticLimits.cs
@@ -1,0 +1,74 @@
+﻿#region ================== Copyright (c) 2021 Derek MacDonald
+
+/*
+ * Copyright (c) 2021 Derek MacDonald
+ * This program is released under GNU General Public License
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ */
+
+#endregion
+
+#region ================== Namespaces
+
+using CodeImp.DoomBuilder.IO;
+using System;
+
+#endregion
+
+namespace CodeImp.DoomBuilder.Config
+{
+	public class StaticLimits
+	{
+		#region ================== Constants
+
+		private const uint DEFAULT_MAX_VISPLANES = 128;
+		private const uint DEFAULT_MAX_VISPLANES_LIMIT = DEFAULT_MAX_VISPLANES * 2;
+		private const uint MAX_DRAWSEGS = 256;
+		private const uint MAX_SOLIDSEGS = 32;
+		private const uint MAX_OPENINGS = 320 * 64;
+
+		#endregion
+
+		#region ================== Variables
+
+		private uint visplanes;
+		private static uint maxvisplaneslimit;
+
+		#endregion
+
+		#region ================== Properties
+
+		public uint Visplanes { get { return visplanes; } }
+		public uint Drawsegs { get { return MAX_DRAWSEGS; } }
+		public uint Solidsegs { get { return MAX_SOLIDSEGS; } }
+		public uint Openings { get { return MAX_OPENINGS; } }
+
+		#endregion
+
+		// Constructor
+		internal StaticLimits(Configuration cfg)
+		{
+			visplanes = (uint)cfg.ReadSetting("staticlimits.visplanes", DEFAULT_MAX_VISPLANES);
+			maxvisplaneslimit = visplanes * 2;
+		}
+
+		#region ================== Methods
+
+		// This interpolates the supported visplane count to default range 1-255
+		// where 128 is the configured static limit.
+		public byte InterpolateVisplanes(byte value)
+		{
+			if (visplanes == DEFAULT_MAX_VISPLANES) return value;
+
+			double v = DEFAULT_MAX_VISPLANES_LIMIT * value / maxvisplaneslimit;
+			return (byte)Math.Ceiling(v);
+		}
+
+		#endregion
+	}
+}

--- a/Source/Plugins/VisplaneExplorer/Tile.cs
+++ b/Source/Plugins/VisplaneExplorer/Tile.cs
@@ -13,7 +13,6 @@ namespace CodeImp.DoomBuilder.Plugins.VisplaneExplorer
 		// Constants
 		public const int TILE_SIZE = 64;
 		public static readonly int[] STATS_COMPRESSOR = new[] { 1, 2, 1, 160 };
-		public static readonly int[] STATS_LIMITS = new[] { 128, 256, 32, 320 * 64 };
 		public const uint POINT_MAXRANGE = 254;
 		public const uint POINT_OVERFLOW = 0xFEFEFEFE;
 		public const uint POINT_VOID = 0xFFFFFFFF;
@@ -91,6 +90,15 @@ namespace CodeImp.DoomBuilder.Plugins.VisplaneExplorer
 			{
 				return vp + (ds << 8) + (ss << 16) + (op << 24);
 			}
+		}
+
+		// This returns a point value for the heatmap
+		public byte GetHeatmapByte(int x, int y, int stat)
+		{
+			byte b = GetPointByte(x, y, stat);
+			if (stat == (int)ViewStats.Visplanes && b != 0 && b != POINT_VOID_B)
+				b = General.Map.Config.StaticLimits.InterpolateVisplanes(b);
+			return b;
 		}
 
 		// This returns a point value

--- a/Source/Plugins/VisplaneExplorer/VisplaneExplorerMode.cs
+++ b/Source/Plugins/VisplaneExplorer/VisplaneExplorerMode.cs
@@ -165,7 +165,7 @@ namespace CodeImp.DoomBuilder.Plugins.VisplaneExplorer
 						float uy = y * hinv * Tile.TILE_SIZE;
 
 						// Get the data and apply the color
-						byte value = t.Value.GetPointByte((int)ux, Tile.TILE_SIZE - 1 - (int)uy, viewstats);
+						byte value = t.Value.GetHeatmapByte((int)ux, Tile.TILE_SIZE - 1 - (int)uy, viewstats);
 						p[screeny * bd.Width + screenx] = (uint)pal.Colors[value];
 					}
 				}
@@ -456,7 +456,7 @@ namespace CodeImp.DoomBuilder.Plugins.VisplaneExplorer
 						int value = t.GetPointValue(x, y, viewstats);
 						Point p = new Point((int)mousepos.x + 5, (int)mousepos.y + 5);
 						string appendoverflow = (b == Tile.POINT_OVERFLOW_B) ? "+" : "";
-						BuilderPlug.InterfaceForm.ShowTooltip(value + appendoverflow + " / " + Tile.STATS_LIMITS[viewstats], p);
+						BuilderPlug.InterfaceForm.ShowTooltip(value + appendoverflow + " / " + StaticLimit(BuilderPlug.InterfaceForm.ViewStats), p);
 					}
 					else
 					{
@@ -489,6 +489,23 @@ namespace CodeImp.DoomBuilder.Plugins.VisplaneExplorer
 			General.Interface.RedrawDisplay();
 		}
 
+		// Get the configured static limit for the given stat.
+		private uint StaticLimit(ViewStats stat)
+		{
+			switch (stat)
+			{
+				case ViewStats.Visplanes:
+					return General.Map.Config.StaticLimits.Visplanes;
+				case ViewStats.Drawsegs:
+					return General.Map.Config.StaticLimits.Drawsegs;
+				case ViewStats.Solidsegs:
+					return General.Map.Config.StaticLimits.Solidsegs;
+				case ViewStats.Openings:
+					return General.Map.Config.StaticLimits.Openings;
+				default:
+					return 0;
+			}
+		}
 		#endregion
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/jewalky/UltimateDoomBuilder/issues/431

https://doomwiki.org/wiki/Static_limits

Doom's 128 VPO limit is raised by Hexen (160) & Strife (200) so make it configurable by base game.

The hover tooltip will reflect the adjusted max limit and the heatmap is interpolated to 0-255 for the 256x10 colour range gradient ( https://github.com/jewalky/UltimateDoomBuilder/blob/master/Source/Plugins/VisplaneExplorer/Resources/Visplanes_pal.png ) so red will be drawn where the increased limit is detected.

The drawseg, solidseg, and opening limits are just stored as constants as those are always the same in vanilla. Strife: Veteran Edition and the Classic Doom (including Unity) source ports up or remove those limits. If such increased values were supported (along with a VPO limit above 255), the `#define` constants in Andrew Apted's base C code would need to be increased again. I can't be bothered - the brute-force Visplane Explorer takes up enough memory as-is.

Hexen MAP01 that has visplanes above Doom's vanilla limit:

![hexen-map01](https://user-images.githubusercontent.com/823566/113950399-39e8ee80-97df-11eb-951a-7d5671b4ceb6.png)