### PR TITLE
Couldn't compile on linux for hours without this

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ These instructions are for Debian-based distros and were tested with Debian 10 a
 __Note:__ this is experimental. None of the developers are using Linux as a desktop OS, so you're pretty much on your own if you encounter any problems with running the application.
 
 - Install Mono. The `mono-complete` package from the Debian repo doesn't include `msbuild`, so you have to install `mono-complete` by following the instructions on the Mono project's website: https://www.mono-project.com/download/stable/#download-lin
+- mono-roslyn package has msbuild
 - Install additional required packages: `sudo apt install make g++ git libx11-dev mesa-common-dev`
 - Go to a directory of your choice and clone the repository (it'll automatically create an `UltimateDoomBuilder` directory in the current directory): `git clone https://github.com/jewalky/UltimateDoomBuilder.git`
 - Compile UDB: `cd UltimateDoomBuilder && make`


### PR DESCRIPTION
I spent all my night, at least 5 hours trying to find out why I cannot install it on linux. This msbuild didn't want to come anyhow I installed mono. And after time I read somewhere to install mono-roslyn. I have no idea why and how but it helped. I am sleepy and tired because of this, but I want to share this knowledge with others, so they won't have to suffer.