### PR TITLE
Game Configuration modal dialog: skip validating resource files of unchecked games

### DIFF
--- a/Source/Core/Windows/ConfigForm.cs
+++ b/Source/Core/Windows/ConfigForm.cs
@@ -395,7 +395,7 @@ namespace CodeImp.DoomBuilder.Windows
 			{
 				// Get configuration item
 				ci = listconfigs.Items[i].Tag as ConfigurationInfo;
-				if(!ci.Resources.IsValid())
+				if(listconfigs.Items[i].Checked && !ci.Resources.IsValid())
 				{
 					MessageBox.Show(this, "At least one resource doesn't exist in \"" + ci.Name + "\" game configuration!", Application.ProductName, MessageBoxButtons.OK, MessageBoxIcon.Warning);
 					tabs.SelectedTab = tabresources;


### PR DESCRIPTION
Discord chat reference: https://discord.com/channels/659791526586613770/659795578649313331/831371941822595093

Allow base games to be (un/re)-installed while keeping the UDB configs. Don't validate IWAD, etc. resources exist for game configurations that are unchecked.

In the below screenshot, I've uninstalled Hexen in Steam but UDB has a blocking modal dialog when that game is unchecked.

![steam-uninstalled](https://user-images.githubusercontent.com/823566/129081754-df08f74f-3ce3-4135-9f8e-458ca82dd14f.png)

Example steps:

1. Install Hexen on Steam
2. Add game configuration for "Hexen: Hexen (Hexen format)" using Steam's hexen.wad IWAD path.
3. Click OK in the Game Configurations modal dialog.
4. Uninstall Hexen on Steam.
5. Return to the Game Configuration modal dialog and uncheck "Hexen: Hexen (Hexen format)".
6. Then click OK or attempt to make any other change in another game config tab like Doom.

You'll receive blocking error message "At least one resource doesn't exist in "Hexen: Hexen (Hexen format)" game configuration!" when that config isn't enabled. This change allows games to be uninstalled but their UDB configs still kept for later when the game is reinstalled.

---

Note this change doesn't affect the "Open Map" modal dialog that performs its own resource checks:

https://github.com/jewalky/UltimateDoomBuilder/blob/601d741b7ee94eac8e555ff971b88a2327aa9b54/Source/Core/Windows/MapOptionsForm.cs#L159-L164

https://github.com/jewalky/UltimateDoomBuilder/blob/601d741b7ee94eac8e555ff971b88a2327aa9b54/Source/Core/Windows/OpenMapOptionsForm.cs#L435-L440

In the below screenshot for a map with an existing `.dbs` file, UDB's "Eternity: Doom 2 (UDMF)" game configuration is unchecked and the doom2.wad IWAD path is missing. In this case, you _do_ want the missing resource(s) to be blocking.

![open-map-validation](https://user-images.githubusercontent.com/823566/129081926-a2d638dc-922d-44eb-a335-9e47677e880a.png)
