### PR TITLE
Don't auto-add upper texture for lower adjacent sky sectors

### DIFF
--- a/Source/Core/Geometry/Tools.cs
+++ b/Source/Core/Geometry/Tools.cs
@@ -2006,8 +2006,8 @@ namespace CodeImp.DoomBuilder.Geometry
 
 			if (side.Line.IsFlagSet(General.Map.Config.LowerUnpeggedFlag)) 
 			{
-				if(side.Other == null || side.Other.Sector == null || side.Sector.CeilTexture != General.Map.Config.SkyFlatName ||
-					side.Other.Sector.CeilTexture != General.Map.Config.SkyFlatName)
+				if(side.Other == null || side.Other.Sector == null || !side.Sector.HasSkyCeiling ||
+					!side.Other.Sector.HasSkyCeiling)
 					return offset;
 
 				//normalize offset the way Doom does it when front and back sector's ceiling is sky
@@ -2447,7 +2447,7 @@ namespace CodeImp.DoomBuilder.Geometry
 
 			//Update the flag
 			if(General.Map.Data.MapInfo.HasFadeColor ||
-			   (General.Map.Data.MapInfo.HasOutsideFogColor && side.Sector.CeilTexture == General.Map.Config.SkyFlatName) ||
+			   (General.Map.Data.MapInfo.HasOutsideFogColor && side.Sector.HasSkyCeiling) ||
 			   side.Sector.Fields.ContainsKey("fadecolor")) 
 			{
 				//Set the flag
@@ -2508,7 +2508,7 @@ namespace CodeImp.DoomBuilder.Geometry
 		public static PixelColor GetSectorFadeColor(Sector s)
 		{
 			if(s.Fields.ContainsKey("fadecolor")) return PixelColor.FromInt(s.Fields.GetValue("fadecolor", 0));
-			if(General.Map.Data.MapInfo.HasOutsideFogColor && s.CeilTexture == General.Map.Config.SkyFlatName)
+			if(General.Map.Data.MapInfo.HasOutsideFogColor && s.HasSkyCeiling)
 				return PixelColor.FromColor(General.Map.Data.MapInfo.OutsideFogColor.ToColor());
 
 			return PixelColor.FromColor(General.Map.Data.MapInfo.HasFadeColor ? General.Map.Data.MapInfo.FadeColor.ToColor() : Color.Black);

--- a/Source/Core/Map/Sector.cs
+++ b/Source/Core/Map/Sector.cs
@@ -106,6 +106,9 @@ namespace CodeImp.DoomBuilder.Map
 		public string CeilTexture { get { return ceiltexname; } }
 		public long LongFloorTexture { get { return longfloortexname; } }
 		public long LongCeilTexture { get { return longceiltexname; } }
+		public bool HasSkyCeiling { get { return ceiltexname == General.Map.Config.SkyFlatName; } }
+		public bool HasSkyFloor { get { return floortexname == General.Map.Config.SkyFlatName; } }
+
 		internal Dictionary<string, bool> Flags { get { return flags; } } //mxd
 		public int Effect { get { return effect; } set { BeforePropsChange(); effect = value; } }
 		public int Tag { get { return tags[0]; } set { BeforePropsChange(); tags[0] = value; if((value < General.Map.FormatInterface.MinTag) || (value > General.Map.FormatInterface.MaxTag)) throw new ArgumentOutOfRangeException("Tag", "Invalid tag number"); } } //mxd
@@ -894,7 +897,7 @@ namespace CodeImp.DoomBuilder.Map
 			}
 			// Sector uses outisde fog when it's ceiling is sky or Sector_Outside effect (87) is set
 			else if(General.Map.Data.MapInfo.HasOutsideFogColor && 
-				(ceiltexname == General.Map.Config.SkyFlatName || (effect == 87 && General.Map.Config.SectorEffects.ContainsKey(effect))))
+				(HasSkyCeiling || (effect == 87 && General.Map.Config.SectorEffects.ContainsKey(effect))))
 			{
 				fogcolor = General.Map.Data.MapInfo.OutsideFogColor;
 				fogmode = SectorFogMode.OUTSIDEFOGDENSITY;

--- a/Source/Core/Map/Sidedef.cs
+++ b/Source/Core/Map/Sidedef.cs
@@ -402,51 +402,48 @@ namespace CodeImp.DoomBuilder.Map
 		public bool HighRequired()
 		{
 			// Doublesided?
-			if(Other != null)
+			if(Other == null || Other.sector.HasSkyCeiling) return false;
+
+			//mxd. Check sloped ceilings...
+			if(General.Map.UDMF && this.sector != Other.Sector) 
 			{
-				//mxd. Check sloped ceilings...
-				if(General.Map.UDMF && this.sector != Other.Sector) 
+				double thisstartz = this.sector.CeilHeight;
+				double thisendz = this.sector.CeilHeight;
+				double otherstartz = Other.sector.CeilHeight;
+				double otherendz = Other.sector.CeilHeight;
+
+				// Check if this side is affected by UDMF slope (it overrides vertex heights, riiiiiight?..) TODO: check this!
+				if(this.sector.CeilSlope.GetLengthSq() > 0) 
 				{
-					double thisstartz = this.sector.CeilHeight;
-					double thisendz = this.sector.CeilHeight;
-					double otherstartz = Other.sector.CeilHeight;
-					double otherendz = Other.sector.CeilHeight;
-
-					// Check if this side is affected by UDMF slope (it overrides vertex heights, riiiiiight?..) TODO: check this!
-					if(this.sector.CeilSlope.GetLengthSq() > 0) 
-					{
-						Plane ceil = new Plane(this.sector.CeilSlope, this.sector.CeilSlopeOffset);
-						thisstartz = ceil.GetZ(this.Line.Start.Position);
-						thisendz = ceil.GetZ(this.Line.End.Position);
-					} 
-					else if(this.sector.Sidedefs.Count == 3) // Check vertex heights on this side
-					{
-						if(!double.IsNaN(this.Line.Start.ZCeiling)) thisstartz = this.Line.Start.ZCeiling;
-						if(!double.IsNaN(this.Line.End.ZCeiling)) thisendz = this.Line.End.ZCeiling;
-					}
-
-					// Check if other side is affected by UDMF slope (it overrides vertex heights, riiiiiight?..) TODO: check this!
-					if(Other.sector.CeilSlope.GetLengthSq() > 0) 
-					{
-						Plane ceil = new Plane(Other.sector.CeilSlope, Other.sector.CeilSlopeOffset);
-						otherstartz = ceil.GetZ(this.Line.Start.Position);
-						otherendz = ceil.GetZ(this.Line.End.Position);
-					} 
-					else if(Other.sector.Sidedefs.Count == 3) // Check other line's vertex heights
-					{
-						if(!double.IsNaN(this.Line.Start.ZCeiling)) otherstartz = this.Line.Start.ZCeiling;
-						if(!double.IsNaN(this.Line.End.ZCeiling)) otherendz = this.Line.End.ZCeiling;
-					}
-
-					// Texture is required when our start or end vertex is higher than on the other side.
-					if(thisstartz > otherstartz || thisendz > otherendz) return true;
+					Plane ceil = new Plane(this.sector.CeilSlope, this.sector.CeilSlopeOffset);
+					thisstartz = ceil.GetZ(this.Line.Start.Position);
+					thisendz = ceil.GetZ(this.Line.End.Position);
+				} 
+				else if(this.sector.Sidedefs.Count == 3) // Check vertex heights on this side
+				{
+					if(!double.IsNaN(this.Line.Start.ZCeiling)) thisstartz = this.Line.Start.ZCeiling;
+					if(!double.IsNaN(this.Line.End.ZCeiling)) thisendz = this.Line.End.ZCeiling;
 				}
-				
-				// Texture is required when ceiling of other side is lower
-				return (Other.sector.CeilHeight < this.sector.CeilHeight);
-			}
 
-			return false;
+				// Check if other side is affected by UDMF slope (it overrides vertex heights, riiiiiight?..) TODO: check this!
+				if(Other.sector.CeilSlope.GetLengthSq() > 0) 
+				{
+					Plane ceil = new Plane(Other.sector.CeilSlope, Other.sector.CeilSlopeOffset);
+					otherstartz = ceil.GetZ(this.Line.Start.Position);
+					otherendz = ceil.GetZ(this.Line.End.Position);
+				} 
+				else if(Other.sector.Sidedefs.Count == 3) // Check other line's vertex heights
+				{
+					if(!double.IsNaN(this.Line.Start.ZCeiling)) otherstartz = this.Line.Start.ZCeiling;
+					if(!double.IsNaN(this.Line.End.ZCeiling)) otherendz = this.Line.End.ZCeiling;
+				}
+
+				// Texture is required when our start or end vertex is higher than on the other side.
+				if(thisstartz > otherstartz || thisendz > otherendz) return true;
+			}
+				
+			// Texture is required when ceiling of other side is lower
+			return Other.sector.CeilHeight < this.sector.CeilHeight;
 		}
 
 		/// <summary>
@@ -464,51 +461,48 @@ namespace CodeImp.DoomBuilder.Map
 		public bool LowRequired()
 		{
 			// Doublesided?
-			if(Other != null)
+			if (Other == null || Other.sector.HasSkyFloor) return false;
+
+			//mxd. Check sloped floors...
+			if(General.Map.UDMF && this.sector != Other.Sector)
 			{
-				//mxd. Check sloped floors...
-				if(General.Map.UDMF && this.sector != Other.Sector)
+				double thisstartz = this.sector.FloorHeight;
+				double thisendz = this.sector.FloorHeight;
+				double otherstartz = Other.sector.FloorHeight;
+				double otherendz = Other.sector.FloorHeight;
+
+				// Check if this side is affected by UDMF slope (it overrides vertex heights, riiiiiight?..) TODO: check this!
+				if(this.sector.FloorSlope.GetLengthSq() > 0) 
 				{
-					double thisstartz = this.sector.FloorHeight;
-					double thisendz = this.sector.FloorHeight;
-					double otherstartz = Other.sector.FloorHeight;
-					double otherendz = Other.sector.FloorHeight;
-
-					// Check if this side is affected by UDMF slope (it overrides vertex heights, riiiiiight?..) TODO: check this!
-					if(this.sector.FloorSlope.GetLengthSq() > 0) 
-					{
-						Plane floor = new Plane(this.sector.FloorSlope, this.sector.FloorSlopeOffset);
-						thisstartz = floor.GetZ(this.Line.Start.Position);
-						thisendz = floor.GetZ(this.Line.End.Position);
-					} 
-					else if(this.sector.Sidedefs.Count == 3) // Check vertex heights on this side
-					{
-						if(!double.IsNaN(this.Line.Start.ZFloor)) thisstartz = this.Line.Start.ZFloor;
-						if(!double.IsNaN(this.Line.End.ZFloor)) thisendz = this.Line.End.ZFloor;
-					}
+					Plane floor = new Plane(this.sector.FloorSlope, this.sector.FloorSlopeOffset);
+					thisstartz = floor.GetZ(this.Line.Start.Position);
+					thisendz = floor.GetZ(this.Line.End.Position);
+				} 
+				else if(this.sector.Sidedefs.Count == 3) // Check vertex heights on this side
+				{
+					if(!double.IsNaN(this.Line.Start.ZFloor)) thisstartz = this.Line.Start.ZFloor;
+					if(!double.IsNaN(this.Line.End.ZFloor)) thisendz = this.Line.End.ZFloor;
+				}
 					
-					// Check if other side is affected by UDMF slope (it overrides vertex heights, riiiiiight?..) TODO: check this!
-					if(Other.sector.FloorSlope.GetLengthSq() > 0)
-					{
-						Plane floor = new Plane(Other.sector.FloorSlope, Other.sector.FloorSlopeOffset);
-						otherstartz = floor.GetZ(this.Line.Start.Position);
-						otherendz = floor.GetZ(this.Line.End.Position);
-					}
-					else if(Other.sector.Sidedefs.Count == 3) // Check other line's vertex heights
-					{
-						if(!double.IsNaN(this.Line.Start.ZFloor)) otherstartz = this.Line.Start.ZFloor;
-						if(!double.IsNaN(this.Line.End.ZFloor)) otherendz = this.Line.End.ZFloor;
-					}
-
-					// Texture is required when our start or end vertex is lower than on the other side.
-					if(thisstartz < otherstartz || thisendz < otherendz) return true;
+				// Check if other side is affected by UDMF slope (it overrides vertex heights, riiiiiight?..) TODO: check this!
+				if(Other.sector.FloorSlope.GetLengthSq() > 0)
+				{
+					Plane floor = new Plane(Other.sector.FloorSlope, Other.sector.FloorSlopeOffset);
+					otherstartz = floor.GetZ(this.Line.Start.Position);
+					otherendz = floor.GetZ(this.Line.End.Position);
+				}
+				else if(Other.sector.Sidedefs.Count == 3) // Check other line's vertex heights
+				{
+					if(!double.IsNaN(this.Line.Start.ZFloor)) otherstartz = this.Line.Start.ZFloor;
+					if(!double.IsNaN(this.Line.End.ZFloor)) otherendz = this.Line.End.ZFloor;
 				}
 
-				// Texture is required when floor of other side is higher
-				return (Other.sector.FloorHeight > this.sector.FloorHeight);
+				// Texture is required when our start or end vertex is lower than on the other side.
+				if(thisstartz < otherstartz || thisendz < otherendz) return true;
 			}
 
-			return false;
+			// Texture is required when floor of other side is higher
+			return Other.sector.FloorHeight > this.sector.FloorHeight;
 		}
 
 		/// <summary>

--- a/Source/Plugins/BuilderModes/ErrorChecks/CheckMissingTextures.cs
+++ b/Source/Plugins/BuilderModes/ErrorChecks/CheckMissingTextures.cs
@@ -63,10 +63,8 @@ namespace CodeImp.DoomBuilder.BuilderModes
 					if (sd.HighRequired())
 					{
 						if (sd.Line.Action == 181 && sd.Line.Args[1] > 0) continue; //mxd. Ceiling slopes doesn't require upper texture
-						if (sd.Other != null && !sd.Other.Sector.HasSkyCeiling)
-						{
-							SubmitResult(new ResultMissingTexture(sd, SidedefPart.Upper));
-						}
+
+						SubmitResult(new ResultMissingTexture(sd, SidedefPart.Upper));
 					}
 					else if (sd.Other != null)
 					{
@@ -112,10 +110,8 @@ namespace CodeImp.DoomBuilder.BuilderModes
 					if (sd.LowRequired())
 					{
 						if (sd.Line.Action == 181 && sd.Line.Args[0] > 0) continue; //mxd. Floor slopes doesn't require lower texture
-						if (sd.Other != null && !sd.Other.Sector.HasSkyFloor)
-						{
-							SubmitResult(new ResultMissingTexture(sd, SidedefPart.Lower));
-						}
+
+						SubmitResult(new ResultMissingTexture(sd, SidedefPart.Lower));
 					}
 					else if (sd.Other != null)
 					{

--- a/Source/Plugins/BuilderModes/ErrorChecks/CheckMissingTextures.cs
+++ b/Source/Plugins/BuilderModes/ErrorChecks/CheckMissingTextures.cs
@@ -63,7 +63,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 					if (sd.HighRequired())
 					{
 						if (sd.Line.Action == 181 && sd.Line.Args[1] > 0) continue; //mxd. Ceiling slopes doesn't require upper texture
-						if (sd.Other != null && sd.Other.Sector.CeilTexture != General.Map.Config.SkyFlatName)
+						if (sd.Other != null && !sd.Other.Sector.HasSkyCeiling)
 						{
 							SubmitResult(new ResultMissingTexture(sd, SidedefPart.Upper));
 						}
@@ -112,7 +112,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 					if (sd.LowRequired())
 					{
 						if (sd.Line.Action == 181 && sd.Line.Args[0] > 0) continue; //mxd. Floor slopes doesn't require lower texture
-						if (sd.Other != null && sd.Other.Sector.FloorTexture != General.Map.Config.SkyFlatName)
+						if (sd.Other != null && !sd.Other.Sector.HasSkyFloor)
 						{
 							SubmitResult(new ResultMissingTexture(sd, SidedefPart.Lower));
 						}

--- a/Source/Plugins/BuilderModes/VisualModes/BaseVisualGeometrySidedef.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/BaseVisualGeometrySidedef.cs
@@ -523,7 +523,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		protected void GetLightValue(out int lightvalue, out bool lightabsolute)
 		{
 			lightabsolute = Sidedef.Fields.GetValue("lightabsolute", false);
-			bool affectedbyfog = General.Map.Data.MapInfo.HasFadeColor || (Sector.Sector.CeilTexture == General.Map.Config.SkyFlatName && General.Map.Data.MapInfo.HasOutsideFogColor) || Sector.Sector.Fields.ContainsKey("fadecolor");
+			bool affectedbyfog = General.Map.Data.MapInfo.HasFadeColor || (Sector.Sector.HasSkyCeiling && General.Map.Data.MapInfo.HasOutsideFogColor) || Sector.Sector.Fields.ContainsKey("fadecolor");
 			bool ignorelight = affectedbyfog && !Sidedef.IsFlagSet("lightfog") && !lightabsolute;
 			lightvalue = ignorelight ? 0 : Sidedef.Fields.GetValue("light", 0); //mxd
 			if(ignorelight) lightabsolute = false;

--- a/Source/Plugins/BuilderModes/VisualModes/BaseVisualThing.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/BaseVisualThing.cs
@@ -233,7 +233,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 						// According to Graf, this is incorrect behaviour...
 						// TECH: In (G)ZDoom, this is ignored when ceiling texture is sky or a thing is below a 3D floor
 						// It's probably more involved than this, but for now let's do it only when there are no 3d floors in Thing.Sector...
-						/*if(General.Map.UDMF && sd.LightLevels.Count == 2 && Thing.Sector.CeilTexture != General.Map.Config.SkyFlatName)
+						/*if(General.Map.UDMF && sd.LightLevels.Count == 2 && !Thing.Sector.HasSkyCeiling)
 						{
 							if(sd.Sector.Fields.GetValue("lightfloorabsolute", false))
 								brightness = UniFields.GetInteger(sd.Sector.Fields, "lightfloor");

--- a/Source/Plugins/BuilderModes/VisualModes/VisualCeiling.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualCeiling.cs
@@ -203,7 +203,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 
 			//mxd. Update sky render flag
 			bool isrenderedassky = renderassky;
-			renderassky = (level.sector.CeilTexture == General.Map.Config.SkyFlatName);
+			renderassky = level.sector.HasSkyCeiling;
 			if(isrenderedassky != renderassky && Sector.Sides != null)
 			{
 				// Upper sidedef geometry may need updating...
@@ -216,7 +216,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 					{
 						parts.upper.UpdateSkyRenderFlag();
 					}
-					else if(side.Other != null && side.Other.Sector != null && side.Other.Sector.CeilTexture == General.Map.Config.SkyFlatName)
+					else if(side.Other != null && side.Other.Sector != null && side.Other.Sector.HasSkyCeiling)
 					{
 						// Update upper side of the neightbouring sector, but only when the visual sector already exists. GetVisualSector will create
 						// the visual sector when it does not exist yet, which in turn modifies the mode's allsectors list, which is illegal when done

--- a/Source/Plugins/BuilderModes/VisualModes/VisualFloor.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualFloor.cs
@@ -188,7 +188,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 			}
 
 			//mxd. Update sky render flag
-			renderassky = (level.sector.FloorTexture == General.Map.Config.SkyFlatName);
+			renderassky = level.sector.HasSkyFloor;
 			
 			// Apply vertices
 			base.SetVertices(verts);

--- a/Source/Plugins/BuilderModes/VisualModes/VisualFogBoundary.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualFogBoundary.cs
@@ -138,7 +138,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		private bool IsFogBoundary()
 		{
 			if(Sidedef.Sector.Index == Sidedef.Other.Sector.Index) return false; // There can't be a boundary if both sides are in the same sector.
-			if(Sidedef.Sector.CeilTexture == General.Map.Config.SkyFlatName && Sidedef.Other.Sector.CeilTexture == General.Map.Config.SkyFlatName) return false;
+			if(Sidedef.Sector.HasSkyCeiling && Sidedef.Other.Sector.HasSkyCeiling) return false;
 			return (Sidedef.Sector.FogMode > SectorFogMode.CLASSIC && Sidedef.Other.Sector.FogMode <= SectorFogMode.CLASSIC);
 		}
 

--- a/Source/Plugins/BuilderModes/VisualModes/VisualLower.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualLower.cs
@@ -160,7 +160,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 			double floorbias = (Sidedef.Other.Sector.FloorHeight == Sidedef.Sector.FloorHeight) ? 1.0 : 0.0;
 			if(Sidedef.Line.IsFlagSet(General.Map.Config.LowerUnpeggedFlag))
 			{
-				if(Sidedef.Sector.CeilTexture == General.Map.Config.SkyFlatName && Sidedef.Other.Sector.CeilTexture == General.Map.Config.SkyFlatName) 
+				if(Sidedef.Sector.HasSkyCeiling && Sidedef.Other.Sector.HasSkyCeiling) 
 				{
 					// mxd. Replicate Doom texture offset glitch when front and back sector's ceilings are sky
 					tp.tlt.y = (double)Sidedef.Other.Sector.CeilHeight - Sidedef.Other.Sector.FloorHeight;
@@ -240,7 +240,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		internal void UpdateSkyRenderFlag()
 		{
 			renderassky = (Sidedef.Other != null && Sidedef.Sector != null && Sidedef.Other.Sector != null
-				&& Sidedef.Other.Sector.FloorTexture == General.Map.Config.SkyFlatName
+				&& Sidedef.Other.Sector.HasSkyFloor
 				&& Sidedef.LowTexture == "-");
 		}
 		

--- a/Source/Plugins/BuilderModes/VisualModes/VisualUpper.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualUpper.cs
@@ -227,8 +227,8 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		internal void UpdateSkyRenderFlag()
 		{
 			renderassky = (Sidedef.Other != null && Sidedef.Sector != null && Sidedef.Other.Sector != null
-				&& Sidedef.Other.Sector.CeilTexture == General.Map.Config.SkyFlatName
-				&& (Sidedef.Sector.CeilTexture == General.Map.Config.SkyFlatName || Sidedef.HighTexture == "-")
+				&& Sidedef.Other.Sector.HasSkyCeiling
+				&& (Sidedef.Sector.HasSkyCeiling || Sidedef.HighTexture == "-")
 				);
 		}
 		


### PR DESCRIPTION
![upper-why](https://user-images.githubusercontent.com/823566/129285746-deeb9e68-1862-4eed-bbba-4cc1cf1405f7.png)

When drawing new sectors, UDB will auto-add these upper textures to sky-meets-sky edges when the ceiling heights differ. Likewise for standalone sky sectors below a regular-flat ceiling (think an Iikka window-over-window effect that led to [this other fix](https://github.com/jewalky/UltimateDoomBuilder/commit/8e95b074ec3e57afd9f2161d0ea88872b03423b5#diff-9e7ee8aa0e20f42d982a50a6f219852a5a01672f6c06117432386355c470755fR231).) In-game, these textures are never displayed.

* refactor the long repeating expressions into `Sector` class predicate methods `hasSkyCeiling()` and `hasSkyFloor()`
* `Sidedef` class methods `HighRequired()` and `LowRequired()` will return `false` if the other side has a sky.
* The "Check unused textures" error checker will start reporting these as warnings. This checker is already for the worst OCD aficionados among us.
* The "Check missing textures" error checker is unaffected.