### PR TITLE
[Vanilla/Limit-removing/Boom/MBF21] Improve game detection in "Open Map" modal dialog

### DIFF
--- a/Build/Configurations/Boom_Doom2Doom.cfg
+++ b/Build/Configurations/Boom_Doom2Doom.cfg
@@ -32,6 +32,9 @@ include("Includes\\Boom_common.cfg", "mapformat_doom");
 // Settings common to Doom games
 include("Includes\\Game_Doom.cfg");
 
+// Map name format for Doom 2.
+mapnameformat = "MAPxy";
+
 //mxd. No DECORATE support in vanilla
 decorategames = "";
 

--- a/Build/Configurations/Boom_DoomDoom.cfg
+++ b/Build/Configurations/Boom_DoomDoom.cfg
@@ -29,6 +29,9 @@ include("Includes\\Boom_common.cfg", "mapformat_doom");
 // Settings common to Doom games
 include("Includes\\Game_Doom.cfg");
 
+// Map name format for Doom.
+mapnameformat = "ExMy";
+
 //mxd. No DECORATE support in vanilla
 decorategames = "";
 

--- a/Build/Configurations/Doom_Doom2Doom.cfg
+++ b/Build/Configurations/Doom_Doom2Doom.cfg
@@ -32,6 +32,9 @@ include("Includes\\Doom_common.cfg", "mapformat_doom");
 // Settings common to Doom games
 include("Includes\\Game_Doom.cfg");
 
+// Map name format for Doom 2.
+mapnameformat = "MAPxy";
+
 //mxd. No DECORATE support in vanilla
 decorategames = "";
 

--- a/Build/Configurations/Doom_DoomDoom.cfg
+++ b/Build/Configurations/Doom_DoomDoom.cfg
@@ -29,6 +29,9 @@ include("Includes\\Doom_common.cfg", "mapformat_doom");
 // Settings common to Doom games
 include("Includes\\Game_Doom.cfg");
 
+// Map name format for Doom.
+mapnameformat = "ExMy";
+
 //mxd. No DECORATE support in vanilla
 decorategames = "";
 

--- a/Build/Configurations/Heretic_HereticDoom.cfg
+++ b/Build/Configurations/Heretic_HereticDoom.cfg
@@ -29,6 +29,9 @@ include("Includes\\Heretic_common.cfg", "mapformat_doom");
 // Settings common to Doom games
 include("Includes\\Game_Heretic.cfg");
 
+// Map name format for Heretic.
+mapnameformat = "ExMy";
+
 //mxd. No DECORATE support in vanilla
 decorategames = "";
 

--- a/Build/Configurations/Hexen_HexenHexen.cfg
+++ b/Build/Configurations/Hexen_HexenHexen.cfg
@@ -29,6 +29,9 @@ include("Includes\\Hexen_common.cfg", "mapformat_hexen");
 // Settings common to Hexen games
 include("Includes\\Game_Hexen.cfg");
 
+// Map name format for Hexen.
+mapnameformat = "MAPxy";
+
 //mxd. No DECORATE support in vanilla
 decorategames = "";
 

--- a/Build/Configurations/MBF21_Doom2Doom.cfg
+++ b/Build/Configurations/MBF21_Doom2Doom.cfg
@@ -33,6 +33,9 @@ include("Includes\\MBF21_common.cfg", "mapformat_doom");
 // Settings common to Doom games
 include("Includes\\Game_Doom.cfg");
 
+// Map name format for Doom 2.
+mapnameformat = "MAPxy";
+
 //mxd. No DECORATE support in vanilla
 decorategames = "";
 

--- a/Build/Configurations/Strife_StrifeDoom.cfg
+++ b/Build/Configurations/Strife_StrifeDoom.cfg
@@ -29,6 +29,9 @@ include("Includes\\Strife_common.cfg", "mapformat_doom");
 // Settings common to Strife games
 include("Includes\\Game_Strife.cfg");
 
+// Map name format for Strife.
+mapnameformat = "MAPxy";
+
 //mxd. No DECORATE support in vanilla
 decorategames = "";
 

--- a/Source/Core/General/MapManager.cs
+++ b/Source/Core/General/MapManager.cs
@@ -51,6 +51,8 @@ namespace CodeImp.DoomBuilder
 		internal const string TEMP_MAP_HEADER = "TEMPMAP";
 		internal const string BUILD_MAP_HEADER = "MAP01";
 		public const string CONFIG_MAP_HEADER = "~MAP";
+		public const string CONFIG_MAP_NAME_FORMAT_EPISODE = "ExMy";
+		public const string CONFIG_MAP_NAME_FORMAT_NO_EPISODE = "MAPxy";
 		private const int REPLACE_TARGET_MAP = -1; //mxd
 
 		#endregion


### PR DESCRIPTION
Every time I open a Doom II PWAD for the first time:

![price-is-wrong-bitch](https://user-images.githubusercontent.com/823566/129414977-87976781-cb8a-4350-8660-745f99d9ff13.png)

When opening a PWAD for the first time and the `.dbs` file is missing, better detect the game config by analyzing naming formats of map lumps.

If `MAPxy` is found in the given WAD, don't auto-select:
* Doom 1
* Heretic

If `ExMy` is found, don't auto-select:
* Doom 2
* Hexen
* Strife

So the alphabetical first-matching item in the game configuration dropdown won't be an obvious mismatch.

This change doesn't affect Eternity Engine or ZDoom configs that support arbitrary map names.