### PR TITLE
Update GZBuilder.cfg references in docs to UDBuilder.cfg

### DIFF
--- a/Build/UDBuilder.default.cfg
+++ b/Build/UDBuilder.default.cfg
@@ -2,8 +2,8 @@
 // NOTE: These are the default program settings!
 // GZDoom Builder will use this file to create the program settings for a new user.
 // Your real settings are in the Local Application data directory
-// Windows XP: C:\Documents and Settings\Username\Local Settings\Application Data\Doom Builder\GZBuilder.cfg
-// Windows Vista or later: C:\Users\Username\AppData\Local\Doom Builder\GZBuilder.cfg
+// Windows XP: C:\Documents and Settings\Username\Local Settings\Application Data\Doom Builder\UDBuilder.cfg
+// Windows Vista or later: C:\Users\Username\AppData\Local\Doom Builder\UDBuilder.cfg
 
 shortcuts
 {

--- a/Documents/cmdargs.txt
+++ b/Documents/cmdargs.txt
@@ -45,9 +45,9 @@ and P_END marker lumps only. This can solve lump name conflicts, but old WAD fil
 always adhere to this rule.
 
 -portable
-The editor will be launched in portable mode. It will use the "GZBuilder.cfg" located in 
+The editor will be launched in portable mode. It will use the "UDBuilder.cfg" located in 
 the program directory instead of the one located in the 
-"%LocalAppData%\Doom Builder\GZBuilder.cfg" to load and save program settings. Log and 
+"%LocalAppData%\Doom Builder\UDBuilder.cfg" to load and save program settings. Log and 
 crash report files will be also created in the program directory.
 
 -resource <resource type> [flags] "path\to\resource"

--- a/Help/commandlineparams.html
+++ b/Help/commandlineparams.html
@@ -35,7 +35,7 @@
 		When this parameter is specified, GZDoom Builder will not load your preferences or game	configuration settings and will use the default settings instead.<br />You will not lose your original settings, but when this parameter is specified your settings will not be saved.<br />
 		<br />
 		<b class="fat">-portable</b> - <span class="red">GZDB only.</span><br />
-		The editor will be launched in portable mode. It will use the &quot;GZBuilder.cfg&quot; located in the program directory instead of the one located in the &quot;%LocalAppData%\Doom Builder\GZBuilder.cfg&quot; to load and save program settings. Log and crash report files will be also created in the program directory.<br />
+		The editor will be launched in portable mode. It will use the &quot;UDBuilder.cfg&quot; located in the program directory instead of the one located in the &quot;%LocalAppData%\Doom Builder\UDBuilder.cfg&quot; to load and save program settings. Log and crash report files will be also created in the program directory.<br />
 	<h2>The following parameters are used only when both &quot;wadfile&quot; and &quot;-map&quot; parameters are present</h2>
 	They replicate the settings, which can be set in the <a href="w_openmapoptions.html">Open Map Window</a>.<br />
 	<br />


### PR DESCRIPTION
There's still code to read any GZBuilder.cfg file from previous GZDB[-bugfix] installs but UDB now always writes to file UDBuilder.cfg.