### PR TITLE
Cursor position playtesting: Fix spawning sector height check

### DIFF
--- a/Source/Core/Editing/ClassicMode.cs
+++ b/Source/Core/Editing/ClassicMode.cs
@@ -721,8 +721,9 @@ namespace CodeImp.DoomBuilder.Editing
 					return false;
 				}
 
-				//41 = player's height in Doom. Is that so in all other games as well?
-				if (s.CeilHeight - s.FloorHeight < 41)
+				// Spawning sector height isn't too low to cause a stuck player.
+				int playerheight = General.Map.Config.ReadSetting("thingtypes.players.height", 56);
+				if (s.CeilHeight - s.FloorHeight < playerheight)
 				{
 					General.MainWindow.DisplayStatus(StatusType.Warning, "Can't test from current position: sector is too low!");
 					return false;


### PR DESCRIPTION
41 is the Doom player's view height but the `mobjinfo` height definition is 56. If the player spawns in a sector of height 55 or below, they cannot move. Hexen increases the player height to 64 (https://github.com/elhobbs/hexen/blob/master/source/INFO.c#L10561). Strife & Heretic are still 56.

These values are actually already set in files `Build/Configurations/Includes/*_things.cfg`.