### PR TITLE
Missing/Unused Textures error checks cover actions move floor to lowest/next higher/highest

### DIFF
--- a/Build/Configurations/Includes/Boom_linedefs.cfg
+++ b/Build/Configurations/Includes/Boom_linedefs.cfg
@@ -61,6 +61,11 @@ floor
 	{
 		title = "Floor Lower to Lowest Floor (changes texture)";
 		prefix = "S1";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	160
@@ -85,6 +90,11 @@ floor
 	{
 		title = "Floor Lower to Lowest Floor (changes texture)";
 		prefix = "SR";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	178
@@ -254,6 +264,12 @@ lift
 	{
 		title = "Lift Perpetual Lowest and Highest Floors";
 		prefix = "S1";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+			floorraisetohighest = true;
+		}
 	}
 	
 	163
@@ -266,6 +282,12 @@ lift
 	{
 		title = "Lift Perpetual Lowest and Highest Floors";
 		prefix = "SR";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+			floorraisetohighest = true;
+		}
 	}
 	
 	182
@@ -290,24 +312,44 @@ lift
 	{
 		title = "Lift Raise to Next Highest Floor (fast)";
 		prefix = "W1";
+
+		errorchecker
+		{
+			floorraisetonexthigher = true;
+		}
 	}
 	
 	228
 	{
 		title = "Lift Raise to Next Highest Floor (fast)";
 		prefix = "WR";
+
+		errorchecker
+		{
+			floorraisetonexthigher = true;
+		}
 	}
 	
 	229
 	{
 		title = "Lift Raise to Next Highest Floor (fast)";
 		prefix = "S1";
+
+		errorchecker
+		{
+			floorraisetonexthigher = true;
+		}
 	}
 	
 	230
 	{
 		title = "Lift Raise to Next Highest Floor (fast)";
 		prefix = "SR";
+
+		errorchecker
+		{
+			floorraisetonexthigher = true;
+		}
 	}
 	
 	231

--- a/Build/Configurations/Includes/Doom_linedefs.cfg
+++ b/Build/Configurations/Includes/Doom_linedefs.cfg
@@ -306,30 +306,55 @@ floor
 	{
 		title = "Floor Raise to Next Higher Floor";
 		prefix = "S1";
+
+		errorchecker
+		{
+			floorraisetonexthigher = true;
+		}
 	}
 	
 	19
 	{
 		title = "Floor Lower to Highest Floor";
 		prefix = "W1";
+
+		errorchecker
+		{
+			floorraisetohighest = true;
+		}
 	}
 	
 	20
 	{
 		title = "Floor Raise to Next Higher Floor (changes texture)";
 		prefix = "S1";
+
+		errorchecker
+		{
+			floorraisetonexthigher = true;
+		}
 	}
 	
 	22
 	{
 		title = "Floor Raise to Next Higher Floor (changes texture)";
 		prefix = "W1";
+
+		errorchecker
+		{
+			floorraisetonexthigher = true;
+		}
 	}
 	
 	23
 	{
 		title = "Floor Lower to Lowest Floor";
 		prefix = "S1";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	24
@@ -354,30 +379,56 @@ floor
 	{
 		title = "Floor Lower to Lowest Floor (changes texture)";
 		prefix = "W1";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	38
 	{
 		title = "Floor Lower to Lowest Floor";
 		prefix = "W1";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	45
 	{
 		title = "Floor Lower to Highest Floor";
 		prefix = "SR";
+
+		errorchecker
+		{
+			floorraisetohighest = true;
+		}
 	}
 	
 	47
 	{
 		title = "Floor Raise to Next Higher Floor (changes texture)";
 		prefix = "G1";
+
+		errorchecker
+		{
+			floorraisetonexthigher = true;
+		}
 	}
 	
 	53
 	{
 		title = "Floor Start Moving Up and Down";
 		prefix = "W1";
+
+		errorchecker
+		{
+			floorlowertolowest = true;
+			floorraisetohighest = true;
+		}
 	}
 	
 	54
@@ -414,6 +465,11 @@ floor
 	{
 		title = "Floor Lower to Lowest Floor";
 		prefix = "SR";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	64
@@ -444,12 +500,22 @@ floor
 	{
 		title = "Floor Raise to Next Higher Floor (changes texture)";
 		prefix = "SR";
+
+		errorchecker
+		{
+			floorraisetonexthigher = true;
+		}
 	}
 	
 	69
 	{
 		title = "Floor Raise to Next Higher Floor";
 		prefix = "SR";
+
+		errorchecker
+		{
+			floorraisetonexthigher = true;
+		}
 	}
 	
 	70
@@ -468,24 +534,45 @@ floor
 	{
 		title = "Floor Lower to Lowest Floor";
 		prefix = "WR";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	83
 	{
 		title = "Floor Lower to Highest Floor";
 		prefix = "WR";
+
+		errorchecker
+		{
+			floorraisetohighest = true;
+		}
 	}
 	
 	84
 	{
 		title = "Floor Lower to Lowest Floor (changes texture)";
 		prefix = "WR";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	87
 	{
 		title = "Floor Start Moving Up and Down";
 		prefix = "WR";
+
+		errorchecker
+		{
+			floorlowertolowest = true;
+			floorraisetohighest = true;
+		}
 	}
 	
 	89
@@ -522,6 +609,11 @@ floor
 	{
 		title = "Floor Raise to Next Higher Floor (changes texture)";
 		prefix = "WR";
+
+		errorchecker
+		{
+			floorraisetonexthigher = true;
+		}
 	}
 	
 	96
@@ -546,42 +638,77 @@ floor
 	{
 		title = "Floor Lower to Highest Floor";
 		prefix = "S1";
+
+		errorchecker
+		{
+			floorraisetohighest = true;
+		}
 	}
 	
 	119
 	{
 		title = "Floor Raise to Next Higher Floor";
 		prefix = "W1";
+
+		errorchecker
+		{
+			floorraisetonexthigher = true;
+		}
 	}
 	
 	128
 	{
 		title = "Floor Raise to Next Higher Floor";
 		prefix = "WR";
+
+		errorchecker
+		{
+			floorraisetonexthigher = true;
+		}
 	}
 	
 	129
 	{
 		title = "Floor Raise to Next Higher Floor (fast)";
 		prefix = "WR";
+
+		errorchecker
+		{
+			floorraisetonexthigher = true;
+		}
 	}
 	
 	130
 	{
 		title = "Floor Raise to Next Higher Floor (fast)";
 		prefix = "W1";
+
+		errorchecker
+		{
+			floorraisetonexthigher = true;
+		}
 	}
 	
 	131
 	{
 		title = "Floor Raise to Next Higher Floor (fast)";
 		prefix = "S1";
+
+		errorchecker
+		{
+			floorraisetonexthigher = true;
+		}
 	}
 	
 	132
 	{
 		title = "Floor Raise to Next Higher Floor (fast)";
 		prefix = "SR";
+
+		errorchecker
+		{
+			floorraisetonexthigher = true;
+		}
 	}
 	
 	140
@@ -678,48 +805,88 @@ lift
 	{
 		title = "Lift Lower Wait Raise";
 		prefix = "W1";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	21
 	{
 		title = "Lift Lower Wait Raise";
 		prefix = "S1";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	62
 	{
 		title = "Lift Lower Wait Raise";
 		prefix = "SR";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	88
 	{
 		title = "Lift Lower Wait Raise";
 		prefix = "WR";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	120
 	{
 		title = "Lift Lower Wait Raise (fast)";
 		prefix = "WR";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	121
 	{
 		title = "Lift Lower Wait Raise (fast)";
 		prefix = "W1";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	122
 	{
 		title = "Lift Lower Wait Raise (fast)";
 		prefix = "S1";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	123
 	{
 		title = "Lift Lower Wait Raise (fast)";
 		prefix = "SR";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 }
 

--- a/Build/Configurations/Includes/Eternity_linedefs.cfg
+++ b/Build/Configurations/Includes/Eternity_linedefs.cfg
@@ -600,6 +600,10 @@ udmf
 				type = 11;
 				enum = "change";
 			}
+			errorchecker
+			{
+				floorlowertolowest = true;
+			}
 		}
 		22
 		{
@@ -1102,6 +1106,11 @@ udmf
 				title = "Change";
 				type = 11;
 				enum = "change";
+			}
+
+			errorchecker
+			{
+				floorraisetohighest = true;
 			}
 		}
 		257
@@ -3558,6 +3567,11 @@ udmf
 				type = 11;
 				enum = "plat_speeds";
 				default = 32;
+			}
+
+			errorchecker
+			{
+				floorraisetonexthigher = true;
 			}
 		}
 		246

--- a/Build/Configurations/Includes/Heretic_linedefs.cfg
+++ b/Build/Configurations/Includes/Heretic_linedefs.cfg
@@ -192,30 +192,60 @@ floor
 	{
 		title = "Floor Raise to Next Higher Floor";
 		prefix = "S1";
+
+		errorchecker
+		{
+			floorraisetonexthigher = true;
+		}
+
+		errorchecker
+		{
+			floorraisetonexthigher = true;
+		}
 	}
 	
 	19
 	{
 		title = "Floor Lower to Highest Floor";
 		prefix = "W1";
+
+		errorchecker
+		{
+			floorraisetohighest = true;
+		}
 	}
 	
 	20
 	{
 		title = "Floor Raise to Next Higher Floor (changes texture)";
 		prefix = "S1";
+
+		errorchecker
+		{
+			floorraisetonexthigher = true;
+		}
 	}
 	
 	22
 	{
 		title = "Floor Raise to Next Higher Floor (changes texture)";
 		prefix = "W1";
+
+		errorchecker
+		{
+			floorraisetonexthigher = true;
+		}
 	}
 	
 	23
 	{
 		title = "Floor Lower to Lowest Floor";
 		prefix = "S1";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	24
@@ -240,30 +270,56 @@ floor
 	{
 		title = "Floor Lower to Lowest Floor (changes texture)";
 		prefix = "W1";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	38
 	{
 		title = "Floor Lower to Lowest Floor";
 		prefix = "W1";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	45
 	{
 		title = "Floor Lower to Highest Floor";
 		prefix = "SR";
+
+		errorchecker
+		{
+			floorraisetohighest = true;
+		}
 	}
 	
 	47
 	{
 		title = "Floor Raise to Next Higher Floor (changes texture)";
 		prefix = "G1";
+
+		errorchecker
+		{
+			floorraisetonexthigher = true;
+		}
 	}
 	
 	53
 	{
 		title = "Floor Start Moving Up and Down";
 		prefix = "W1";
+
+		errorchecker
+		{
+			floorlowertolowest = true;
+			floorraisetohighest = true;
+		}
 	}
 	
 	54
@@ -300,6 +356,11 @@ floor
 	{
 		title = "Floor Lower to Lowest Floor";
 		prefix = "SR";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	64
@@ -330,12 +391,22 @@ floor
 	{
 		title = "Floor Raise to Next Higher Floor (changes texture)";
 		prefix = "SR";
+
+		errorchecker
+		{
+			floorraisetonexthigher = true;
+		}
 	}
 	
 	69
 	{
 		title = "Floor Raise to Next Higher Floor";
 		prefix = "SR";
+
+		errorchecker
+		{
+			floorraisetonexthigher = true;
+		}
 	}
 	
 	70
@@ -354,24 +425,45 @@ floor
 	{
 		title = "Floor Lower to Lowest Floor";
 		prefix = "WR";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	83
 	{
 		title = "Floor Lower to Highest Floor";
 		prefix = "WR";
+
+		errorchecker
+		{
+			floorraisetohighest = true;
+		}
 	}
 	
 	84
 	{
 		title = "Floor Lower to Lowest Floor (changes texture)";
 		prefix = "WR";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	87
 	{
 		title = "Floor Start Moving Up and Down";
 		prefix = "WR";
+
+		errorchecker
+		{
+			floorlowertolowest = true;
+			floorraisetohighest = true;
+		}
 	}
 	
 	89
@@ -408,6 +500,11 @@ floor
 	{
 		title = "Floor Raise to Next Higher Floor (changes texture)";
 		prefix = "WR";
+
+		errorchecker
+		{
+			floorraisetonexthigher = true;
+		}
 	}
 	
 	96
@@ -432,6 +529,11 @@ floor
 	{
 		title = "Floor Lower to Highest Floor";
 		prefix = "S1";
+
+		errorchecker
+		{
+			floorraisetohighest = true;
+		}
 	}
 }
 
@@ -504,24 +606,44 @@ lift
 	{
 		title = "Lift Lower Wait Raise";
 		prefix = "W1";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	21
 	{
 		title = "Lift Lower Wait Raise";
 		prefix = "S1";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	62
 	{
 		title = "Lift Lower Wait Raise";
 		prefix = "SR";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	88
 	{
 		title = "Lift Lower Wait Raise";
 		prefix = "WR";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 }
 

--- a/Build/Configurations/Includes/Hexen_linedefs.cfg
+++ b/Build/Configurations/Includes/Hexen_linedefs.cfg
@@ -575,6 +575,11 @@ floor
 			enum = "flat_speeds";
 			default = 16;
 		}
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	22
@@ -640,6 +645,11 @@ floor
 			enum = "flat_speeds";
 			default = 16;
 		}
+
+		errorchecker
+		{
+			floorraisetohighest = true;
+		}
 	}
 	
 	25
@@ -659,6 +669,11 @@ floor
 			type = 11;
 			enum = "flat_speeds";
 			default = 16;
+		}
+
+		errorchecker
+		{
+			floorraisetonexthigher = true;
 		}
 	}
 	
@@ -1318,6 +1333,12 @@ platform
 			enum = "delay_tics";
 			default = 105;
 		}
+
+		errorchecker
+		{
+			floorlowertolowest = true;
+			floorraisetohighest = true;
+		}
 	}
 	
 	61
@@ -1357,6 +1378,11 @@ platform
 			type = 11;
 			enum = "delay_tics";
 			default = 105;
+		}
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
 		}
 	}
 	

--- a/Build/Configurations/Includes/Strife_linedefs.cfg
+++ b/Build/Configurations/Includes/Strife_linedefs.cfg
@@ -626,30 +626,55 @@ floor
 	{
 		title = "Floor Raise to Next Higher Floor";
 		prefix = "S1";
+
+		errorchecker
+		{
+			floorraisetonexthigher = true;
+		}
 	}
 	
 	19
 	{
 		title = "Floor Lower to Highest Floor";
 		prefix = "W1";
+
+		errorchecker
+		{
+			floorraisetohighest = true;
+		}
 	}
 	
 	20
 	{
 		title = "Floor Raise to Next Higher Floor (changes texture)";
 		prefix = "S1";
+
+		errorchecker
+		{
+			floorraisetonexthigher = true;
+		}
 	}
 	
 	22
 	{
 		title = "Floor Raise to Next Higher Floor (changes texture)";
 		prefix = "W1";
+
+		errorchecker
+		{
+			floorraisetonexthigher = true;
+		}
 	}
 	
 	23
 	{
 		title = "Floor Lower to Lowest Floor";
 		prefix = "S1";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	24
@@ -674,30 +699,56 @@ floor
 	{
 		title = "Floor Lower to Lowest Floor (changes texture)";
 		prefix = "W1";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	38
 	{
 		title = "Floor Lower to Lowest Floor";
 		prefix = "W1";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	45
 	{
 		title = "Floor Lower to Highest Floor";
 		prefix = "SR";
+
+		errorchecker
+		{
+			floorraisetohighest = true;
+		}
 	}
 	
 	47
 	{
 		title = "Floor Raise to Next Higher Floor (changes texture)";
 		prefix = "G1";
+
+		errorchecker
+		{
+			floorraisetonexthigher = true;
+		}
 	}
 	
 	53
 	{
 		title = "Floor Start Moving Up and Down";
 		prefix = "W1";
+
+		errorchecker
+		{
+			floorlowertolowest = true;
+			floorraisetohighest = true;
+		}
 	}
 	
 	54
@@ -734,6 +785,11 @@ floor
 	{
 		title = "Floor Lower to Lowest Floor";
 		prefix = "SR";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	64
@@ -764,12 +820,22 @@ floor
 	{
 		title = "Floor Raise to Next Higher Floor (changes texture)";
 		prefix = "SR";
+
+		errorchecker
+		{
+			floorraisetonexthigher = true;
+		}
 	}
 	
 	69
 	{
 		title = "Floor Raise to Next Higher Floor";
 		prefix = "SR";
+
+		errorchecker
+		{
+			floorraisetonexthigher = true;
+		}
 	}
 	
 	70
@@ -788,24 +854,45 @@ floor
 	{
 		title = "Floor Lower to Lowest Floor";
 		prefix = "WR";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	83
 	{
 		title = "Floor Lower to Highest Floor";
 		prefix = "WR";
+
+		errorchecker
+		{
+			floorraisetohighest = true;
+		}
 	}
 	
 	84
 	{
 		title = "Floor Lower to Lowest Floor (changes texture)";
 		prefix = "WR";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	87
 	{
 		title = "Floor Start Moving Up and Down";
 		prefix = "WR";
+
+		errorchecker
+		{
+			floorlowertolowest = true;
+			floorraisetohighest = true;
+		}
 	}
 	
 	89
@@ -866,6 +953,11 @@ floor
 	{
 		title = "Floor Lower to Highest Floor";
 		prefix = "S1";
+
+		errorchecker
+		{
+			floorraisetohighest = true;
+		}
 	}
 	
 	119
@@ -1064,54 +1156,99 @@ lift
 	{
 		title = "Lift Lower Wait Raise";
 		prefix = "W1";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	21
 	{
 		title = "Lift Lower Wait Raise";
 		prefix = "S1";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	62
 	{
 		title = "Lift Lower Wait Raise";
 		prefix = "SR";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	88
 	{
 		title = "Lift Lower Wait Raise";
 		prefix = "WR";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	120
 	{
 		title = "Lift Lower Wait Raise (fast)";
 		prefix = "WR";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	121
 	{
 		title = "Lift Lower Wait Raise (fast)";
 		prefix = "W1";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	122
 	{
 		title = "Lift Lower Wait Raise (fast)";
 		prefix = "S1";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	123
 	{
 		title = "Lift Lower Wait Raise (fast)";
 		prefix = "SR";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	154
 	{
 		title = "Lift Lower Gold Key, Wait, Raise";
 		prefix = "SR";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	155
@@ -1124,6 +1261,11 @@ lift
 	{
 		title = "Lift Lower Power 3 Key, Wait, Up";
 		prefix = "SR";
+		
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
 	}
 	
 	184

--- a/Build/Configurations/Includes/ZDoom_linedefs.cfg
+++ b/Build/Configurations/Includes/ZDoom_linedefs.cfg
@@ -1040,6 +1040,11 @@ zdoom
 				enum = "plat_speeds";
 				default = 16;
 			}
+
+			errorchecker
+			{
+				floorlowertolowest = true;
+			}
 		}
 		
 		242
@@ -1068,6 +1073,11 @@ zdoom
 				title = "Force Adjust";
 				type = 11;
 				enum = "noyes";
+			}
+
+			errorchecker
+			{
+				floorraisetohighest = true;
 			}
 		}
 		250
@@ -4223,6 +4233,11 @@ zdoom
 				type = 11;
 				enum = "plat_speeds";
 				default = 16;
+			}
+
+			errorchecker
+			{
+				floorraisetonexthigher = true;
 			}
 		}
 		246

--- a/Source/Core/Config/LinedefActionInfo.cs
+++ b/Source/Core/Config/LinedefActionInfo.cs
@@ -31,6 +31,9 @@ namespace CodeImp.DoomBuilder.Config
 		public bool IgnoreUpperTexture;
 		public bool IgnoreMiddleTexture;
 		public bool IgnoreLowerTexture;
+		public bool FloorLowerToLowest;
+		public bool FloorRaiseToNextHigher;
+		public bool FloorRaiseToHighest;
 	}
 
 	public class LinedefActionInfo : INumberedTitle, IComparable<LinedefActionInfo>
@@ -114,6 +117,9 @@ namespace CodeImp.DoomBuilder.Config
 			this.errorcheckerexemptions.IgnoreUpperTexture = cfg.ReadSetting(actionsetting + ".errorchecker.ignoreuppertexture", false);
 			this.errorcheckerexemptions.IgnoreMiddleTexture = cfg.ReadSetting(actionsetting + ".errorchecker.ignoremiddletexture", false);
 			this.errorcheckerexemptions.IgnoreLowerTexture = cfg.ReadSetting(actionsetting + ".errorchecker.ignorelowertexture", false);
+			this.errorcheckerexemptions.FloorLowerToLowest = cfg.ReadSetting(actionsetting + ".errorchecker.floorlowertolowest", false);
+			this.errorcheckerexemptions.FloorRaiseToNextHigher = cfg.ReadSetting(actionsetting + ".errorchecker.floorraisetonexthigher", false);
+			this.errorcheckerexemptions.FloorRaiseToHighest = cfg.ReadSetting(actionsetting + ".errorchecker.floorraisetohighest", false);
 
 			// Read the args
 			for (int i = 0; i < Linedef.NUM_ARGS; i++)

--- a/Source/Plugins/BuilderModes/BuilderModes.csproj
+++ b/Source/Plugins/BuilderModes/BuilderModes.csproj
@@ -125,6 +125,10 @@
     <Compile Include="ClassicModes\DrawGeometryMode.cs" />
     <Compile Include="ClassicModes\FindReplaceMode.cs" />
     <Compile Include="ClassicModes\MakeSectorMode.cs" />
+    <Compile Include="ErrorChecks\ActionFloorLowerToLowestTextures.cs" />
+    <Compile Include="ErrorChecks\ActionFloorRaiseToHighestTextures.cs" />
+    <Compile Include="ErrorChecks\ActionFloorRaiseToNextHigherTextures.cs" />
+    <Compile Include="ErrorChecks\BaseActionTextures.cs" />
     <Compile Include="ErrorChecks\BaseCheckTextures.cs" />
     <Compile Include="ErrorChecks\CheckClosedSectors.cs" />
     <Compile Include="ErrorChecks\CheckMissingActivations.cs" />

--- a/Source/Plugins/BuilderModes/BuilderModesMono.csproj
+++ b/Source/Plugins/BuilderModes/BuilderModesMono.csproj
@@ -123,6 +123,10 @@
     <Compile Include="ClassicModes\DrawGeometryMode.cs" />
     <Compile Include="ClassicModes\FindReplaceMode.cs" />
     <Compile Include="ClassicModes\MakeSectorMode.cs" />
+    <Compile Include="ErrorChecks\ActionFloorLowerToLowestTextures.cs" />
+    <Compile Include="ErrorChecks\ActionFloorRaiseToHighestTextures.cs" />
+    <Compile Include="ErrorChecks\ActionFloorRaiseToNextHigherTextures.cs" />
+    <Compile Include="ErrorChecks\BaseActionTextures.cs" />
     <Compile Include="ErrorChecks\BaseCheckTextures.cs" />
     <Compile Include="ErrorChecks\CheckClosedSectors.cs" />
     <Compile Include="ErrorChecks\CheckMissingActivations.cs" />

--- a/Source/Plugins/BuilderModes/ErrorChecks/ActionFloorLowerToLowestTextures.cs
+++ b/Source/Plugins/BuilderModes/ErrorChecks/ActionFloorLowerToLowestTextures.cs
@@ -1,0 +1,40 @@
+﻿
+#region ================== Namespaces
+
+using CodeImp.DoomBuilder.Config;
+using CodeImp.DoomBuilder.Map;
+
+#endregion
+
+namespace CodeImp.DoomBuilder.BuilderModes
+{
+	public class ActionFloorLowerToLowestTextures : BaseActionTextures
+	{
+		#region ================== Methods
+
+		// Gather the lift and lower to lowest floor specials from the configuration.
+		protected override bool InspectsAction(LinedefActionInfo info)
+		{
+			return info.ErrorCheckerExemptions.FloorLowerToLowest;
+		}
+
+		// Determine whether a lower texture is needed after the sector lowers to the lowest neighbour floor.
+		protected override bool HasAdjustedSector(Sidedef side)
+		{
+			int lowestheight = side.Sector.FloorHeight;
+
+			// Find height of the neighbouring sector with the lowest floor.
+			foreach (Sidedef s in side.Sector.Sidedefs)
+			{
+				if (s.Other != null && s.Other.Sector != side.Sector && s.Other.Sector.FloorHeight < lowestheight)
+				{
+					lowestheight = s.Other.Sector.FloorHeight;
+				}
+			}
+
+			return side.Other.Sector.FloorHeight > lowestheight;
+		}
+
+		#endregion
+	}
+}

--- a/Source/Plugins/BuilderModes/ErrorChecks/ActionFloorRaiseToHighestTextures.cs
+++ b/Source/Plugins/BuilderModes/ErrorChecks/ActionFloorRaiseToHighestTextures.cs
@@ -1,0 +1,40 @@
+
+#region ================== Namespaces
+
+using CodeImp.DoomBuilder.Config;
+using CodeImp.DoomBuilder.Map;
+
+#endregion
+
+namespace CodeImp.DoomBuilder.BuilderModes
+{
+    public class ActionFloorRaiseToHighestTextures : BaseActionTextures
+    {
+        #region ================== Methods
+
+        // Gather the raise floor to highest floor specials from the configuration.
+        protected override bool InspectsAction(LinedefActionInfo info)
+        {
+            return info.ErrorCheckerExemptions.FloorRaiseToHighest;
+        }
+
+        // Determine whether a lower texture is needed after the sector raises to the highest neighbour floor.
+        protected override bool HasAdjustedSector(Sidedef side)
+        {
+            int highestheight = side.Sector.FloorHeight;
+
+            // Find height of the highest neighbouring sector floor.
+            foreach (Sidedef s in side.Sector.Sidedefs)
+            {
+                if (s.Other != null && s.Other.Sector != side.Sector && s.Other.Sector.FloorHeight > highestheight)
+                {
+                    highestheight = s.Other.Sector.FloorHeight;
+                }
+            }
+
+            return side.Other.Sector.FloorHeight < highestheight;
+        }
+
+        #endregion
+    }
+}

--- a/Source/Plugins/BuilderModes/ErrorChecks/ActionFloorRaiseToNextHigherTextures.cs
+++ b/Source/Plugins/BuilderModes/ErrorChecks/ActionFloorRaiseToNextHigherTextures.cs
@@ -1,0 +1,40 @@
+
+#region ================== Namespaces
+
+using CodeImp.DoomBuilder.Config;
+using CodeImp.DoomBuilder.Map;
+
+#endregion
+
+namespace CodeImp.DoomBuilder.BuilderModes
+{
+	public class ActionFloorRaiseToNextHigherTextures : BaseActionTextures
+	{
+		#region ================== Methods
+
+		// Gather the raise floor to next higher floor specials from the configuration.
+		protected override bool InspectsAction(LinedefActionInfo info)
+		{
+			return info.ErrorCheckerExemptions.FloorRaiseToNextHigher;
+		}
+
+		// Determine whether a lower texture is needed after the sector raises to the next higher neighbour floor.
+		protected override bool HasAdjustedSector(Sidedef side)
+		{
+			int? nextheight = null;
+
+			// Find height of the lowest neighbouring sector above this floor.
+			foreach (Sidedef s in side.Sector.Sidedefs)
+			{
+				if (s.Other != null && s.Other.Sector.FloorHeight > side.Sector.FloorHeight && (!nextheight.HasValue || s.Other.Sector.FloorHeight < nextheight.Value))
+				{
+					nextheight = s.Other.Sector.FloorHeight;
+				}
+			}
+
+			return nextheight.HasValue && side.Other.Sector.FloorHeight < nextheight.Value;
+		}
+
+		#endregion
+	}
+}

--- a/Source/Plugins/BuilderModes/ErrorChecks/BaseActionTextures.cs
+++ b/Source/Plugins/BuilderModes/ErrorChecks/BaseActionTextures.cs
@@ -1,0 +1,109 @@
+﻿
+#region ================== Namespaces
+
+using CodeImp.DoomBuilder.Config;
+using CodeImp.DoomBuilder.Map;
+using CodeImp.DoomBuilder.Types;
+using System.Collections.Generic;
+
+#endregion
+
+namespace CodeImp.DoomBuilder.BuilderModes
+{
+	public abstract class BaseActionTextures
+	{
+		#region ================== Variables
+
+		private List<int> tags;
+
+		#endregion
+
+		#region ================== Constructor / Destructor
+
+		public BaseActionTextures()
+		{
+			tags = FindTags();
+		}
+
+		#endregion
+
+		#region ================== Methods
+
+		// Determine if the sidedef's sector tag is for an inspected action and the sidedef will require a texture.
+		public bool RequiresTexture(Sidedef side, int tag)
+		{
+			return tags.Contains(tag) &&
+				side.Other != null &&
+				side.Other.Sector != side.Sector &&
+				!side.Other.Sector.Tags.Contains(tag) &&
+				HasAdjustedSector(side);
+		}
+
+		// Gather all sector tags for the linedef actions being inspected.
+		private List<int> FindTags()
+		{
+			List<int> actions = FindActions();
+			List<int> tags = new List<int>();
+			int tag;
+
+			foreach (Linedef ld in General.Map.Map.Linedefs)
+			{
+				if (ld.Action > 0 && actions.Contains(ld.Action))
+				{
+					if (General.Map.HEXEN || General.Map.UDMF)
+						tag = FindArgumentsSectorTag(ld.Action, ld.Args);
+					else
+						tag = ld.Tag;
+
+					if (tag > 0)
+						tags.Add(tag);
+				}
+			}
+
+			if (General.Map.HEXEN || General.Map.UDMF)
+			{
+				foreach (Thing t in General.Map.Map.Things)
+				{
+					if (t.Action > 0 && actions.Contains(t.Action))
+					{
+						tag = FindArgumentsSectorTag(t.Action, t.Args);
+
+						if (tag > 0)
+							tags.Add(tag);
+					}
+				}
+			}
+
+			return tags;
+		}
+
+		// Get the sector tag from linedef/things action arguments.
+		private int FindArgumentsSectorTag(int action, int[] args)
+		{
+			if (General.Map.Config.GetLinedefActionInfo(action).Args[0].Type == (int)UniversalType.SectorTag)
+				return args[0];
+
+			return 0;
+		}
+
+		// Gather the linedef specials from the configuration that this will inspect.
+		private List<int> FindActions()
+		{
+			List<int> actions = new List<int>();
+
+			foreach (LinedefActionInfo info in General.Map.Config.LinedefActions.Values)
+				if (InspectsAction(info))
+					actions.Add(info.Index);
+
+			return actions;
+		}
+
+		// Determine if tagged sectors for the given action will have its textures analyzed.
+		protected abstract bool InspectsAction(LinedefActionInfo info);
+
+		// Determine whether an upper or lower texture is required after the sector tag is activated.
+		protected abstract bool HasAdjustedSector(Sidedef side);
+
+		#endregion
+	}
+}

--- a/Source/Plugins/BuilderModes/ErrorChecks/BaseCheckTextures.cs
+++ b/Source/Plugins/BuilderModes/ErrorChecks/BaseCheckTextures.cs
@@ -18,7 +18,6 @@
 
 using CodeImp.DoomBuilder.Map;
 using System.Collections.Generic;
-using System.Threading;
 using System;
 
 #endregion
@@ -36,6 +35,9 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		#region ================== Variables
 
 		protected Dictionary<int, Flags3DFloor> sector3dfloors;
+		protected ActionFloorLowerToLowestTextures floorlowertolowest;
+		protected ActionFloorRaiseToNextHigherTextures floorraisetonexthigher;
+		protected ActionFloorRaiseToHighestTextures floorraisetohighest;
 
 		#endregion
 
@@ -48,6 +50,9 @@ namespace CodeImp.DoomBuilder.BuilderModes
 			SetTotalProgress(General.Map.Map.Sidedefs.Count / PROGRESS_STEP);
 
 			sector3dfloors = new Dictionary<int, Flags3DFloor>();
+			floorlowertolowest = new ActionFloorLowerToLowestTextures();
+			floorraisetonexthigher = new ActionFloorRaiseToNextHigherTextures();
+			floorraisetohighest = new ActionFloorRaiseToHighestTextures();
 		}
 
 		#endregion
@@ -69,6 +74,12 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		// Create a cache of sectors that have 3D floors, with their flags relevant to the error checker
 		protected void Build3DFloorCache()
 		{
+			// Skip if linedef action 160 isn't the ZDoom 3D floor special.
+			if (General.Map.Config.GetLinedefActionInfo(160).Id != "Sector_Set3dFloor")
+			{
+				return;
+			}
+
 			foreach (Linedef ld in General.Map.Map.Linedefs)
 			{
 				if (ld.Action == 160)

--- a/Source/Plugins/BuilderModes/ErrorChecks/CheckMissingTextures.cs
+++ b/Source/Plugins/BuilderModes/ErrorChecks/CheckMissingTextures.cs
@@ -115,12 +115,19 @@ namespace CodeImp.DoomBuilder.BuilderModes
 					}
 					else if (sd.Other != null)
 					{
-						// Check if the sidedef's sector is a 3D floor. Since it points toward the 3D floor it only needs a texture if inside rendering is enabled
 						if (sd.Sector.Tags.Count > 0)
 						{
 							foreach (int tag in sd.Sector.Tags)
 							{
+								// Check if the sidedef's sector is a 3D floor. Since it points toward the 3D floor it only needs a texture if inside rendering is enabled
 								if (sector3dfloors.ContainsKey(tag) && sector3dfloors[tag].HasFlag(Flags3DFloor.UseLower) && sector3dfloors[tag].HasFlag(Flags3DFloor.RenderInside))
+								{
+									SubmitResult(new ResultMissingTexture(sd, SidedefPart.Lower));
+									break;
+								}
+
+								// Check if the sector is a floor to be lowered.
+								if (floorlowertolowest.RequiresTexture(sd, tag))
 								{
 									SubmitResult(new ResultMissingTexture(sd, SidedefPart.Lower));
 									break;
@@ -128,12 +135,19 @@ namespace CodeImp.DoomBuilder.BuilderModes
 							}
 						}
 
-						// Check if the other sidedef's sector is a 3D floor, since we still might need a texture on this one depending on the flags
 						if (sd.Other.Sector.Tags.Count > 0)
 						{
 							foreach (int tag in sd.Other.Sector.Tags)
 							{
+								// Check if the other sidedef's sector is a 3D floor, since we still might need a texture on this one depending on the flags
 								if (sector3dfloors.ContainsKey(tag) && sector3dfloors[tag].HasFlag(Flags3DFloor.UseLower))
+								{
+									SubmitResult(new ResultMissingTexture(sd, SidedefPart.Lower));
+									break;
+								}
+
+								// Check if the other sidedef's sector is a floor to be raised.
+								if (floorraisetonexthigher.RequiresTexture(sd.Other, tag) || floorraisetohighest.RequiresTexture(sd.Other, tag))
 								{
 									SubmitResult(new ResultMissingTexture(sd, SidedefPart.Lower));
 									break;
@@ -141,7 +155,6 @@ namespace CodeImp.DoomBuilder.BuilderModes
 							}
 						}
 					}
-
 				}
 
 				// Handle thread interruption

--- a/Source/Plugins/BuilderModes/ErrorChecks/CheckUnusedTextures.cs
+++ b/Source/Plugins/BuilderModes/ErrorChecks/CheckUnusedTextures.cs
@@ -86,12 +86,19 @@ namespace CodeImp.DoomBuilder.BuilderModes
 					{
 						bool unused = true;
 
-						// Check if the sidedef's sector is a 3D floor. Since it points toward the 3D floor it only needs a texture if inside rendering is enabled
 						if (sd.Sector.Tags.Count > 0)
 						{
 							foreach (int tag in sd.Sector.Tags)
 							{
+								// Check if the sidedef's sector is a 3D floor. Since it points toward the 3D floor it only needs a texture if inside rendering is enabled
 								if (sector3dfloors.ContainsKey(tag) && sector3dfloors[tag].HasFlag(Flags3DFloor.UseLower) && sector3dfloors[tag].HasFlag(Flags3DFloor.RenderInside))
+								{
+									unused = false;
+									break;
+								}
+
+								// Check if the sector is a floor to be lowered.
+								if (floorlowertolowest.RequiresTexture(sd, tag))
 								{
 									unused = false;
 									break;
@@ -99,12 +106,19 @@ namespace CodeImp.DoomBuilder.BuilderModes
 							}
 						}
 
-						// Check if the other sidedef's sector is a 3D floor, since we still might need a texture on this one depending on the flags
 						if (sd.Other.Sector.Tags.Count > 0)
 						{
 							foreach (int tag in sd.Other.Sector.Tags)
 							{
+								// Check if the other sidedef's sector is a 3D floor, since we still might need a texture on this one depending on the flags
 								if (sector3dfloors.ContainsKey(tag) && sector3dfloors[tag].HasFlag(Flags3DFloor.UseLower))
+								{
+									unused = false;
+									break;
+								}
+
+								// Check if the other sidedef's sector is a floor to be raised.
+								if (floorraisetonexthigher.RequiresTexture(sd.Other, tag) || floorraisetohighest.RequiresTexture(sd.Other, tag))
 								{
 									unused = false;
 									break;


### PR DESCRIPTION
Fixes: https://github.com/jewalky/UltimateDoomBuilder/issues/147

If a sector has a lift, floor lower, or floor raise action tag that will move the sector to the a neighbour height, don't report its lower textures as unused in the error checker. These textures are required when the floor later moves so likewise report when they're missing.

This covers actions that:

* lowers the floor to the lowest neighbour sector (includes lifts)
* raises the floor to the next higher neighbour
* raises the floor to the highest neighbour
* both lowers to lowest & raises to highest (perpetual lifts)

This doesn't cover:

* ACS-triggered actions, obviously.
* Linedef actions that lower or raise the floor in increments, neither the 24mu-rise nor Hexen/ZDoom's arbitrary lip value.
* Stair builder actions for sectors even with the surrounding floor that will need a lower texture when that inner floor raises.

The new `BaseActionTextures` class can be used to implement other sector action exceptions when checking required textures. Good luck to whoever wants to attempt the stairbuilder specials.

> Also: skip the error checkers' 3D floors linedefs loop when the ZDoom config isn't active. Boom & Strife have their own action number 160 and the action arg bitwise checks can be avoided.