### PR TITLE
Avoid infinite recursion in script editor's Find/Replace All

### DIFF
--- a/Source/Core/Controls/Scripting/ScriptDocumentTab.cs
+++ b/Source/Core/Controls/Scripting/ScriptDocumentTab.cs
@@ -356,6 +356,12 @@ namespace CodeImp.DoomBuilder.Controls
 			editor.ReplaceSelection(replacement);
 		}
 
+		// Save one undo checkpoint when making many changes in the editor.
+		public void UndoTransaction(Action callback)
+		{
+			editor.UndoTransaction(callback);
+		}
+
 		//mxd
 		internal List<CompilerError> UpdateNavigator()
 		{

--- a/Source/Core/Controls/Scripting/ScriptEditorControl.cs
+++ b/Source/Core/Controls/Scripting/ScriptEditorControl.cs
@@ -683,7 +683,10 @@ namespace CodeImp.DoomBuilder.Controls
 			// Wrap around?
 			if(result == -1)
 			{
-				if(options.SearchMode != FindReplaceSearchMode.CURRENT_FILE 
+				if (options.WrapAroundDisabled)
+					return false;
+
+				if (options.SearchMode != FindReplaceSearchMode.CURRENT_FILE 
 					&& OnFindNextWrapAround != null && OnFindNextWrapAround(options))
 				{
 					return true;

--- a/Source/Core/Controls/Scripting/ScriptEditorControl.cs
+++ b/Source/Core/Controls/Scripting/ScriptEditorControl.cs
@@ -536,6 +536,21 @@ namespace CodeImp.DoomBuilder.Controls
 			return scriptedit.GetWordFromPosition(position);
 		}
 
+		// Save one undo checkpoint when making many changes in the editor.
+		public void UndoTransaction(Action callback)
+		{
+			scriptedit.BeginUndoAction();
+
+			try
+			{
+				callback.Invoke();
+			}
+			finally
+			{
+				scriptedit.EndUndoAction();
+			}
+		}
+
 		// Perform undo
 		public void Undo()
 		{

--- a/Source/Core/Controls/Scripting/ScriptEditorPanel.cs
+++ b/Source/Core/Controls/Scripting/ScriptEditorPanel.cs
@@ -283,26 +283,25 @@ namespace CodeImp.DoomBuilder.Controls
 				tabs.ResumeLayout();
 			}
 		}
-		
+
 		#endregion
-		
+
 		#region ================== Methods
 
-        // [ZZ] Find and Replace
-        //      This needs to be done in the script editor class, because we don't want to loop over the same value
-        //      And for this, we need to know the context properly, not just "while FindNext && Replace".
-        //      Which means there should be a function that does both find and replace manually.
-        public int FindReplace(FindReplaceOptions options)
+		// [ZZ] Find and Replace
+		//      Search the editor text with wrap-around disabled to avoid infinite
+		//      recursion when the searched phrase is a substring of the replacement.
+		public int FindReplace(FindReplaceOptions options)
         {
-            // [ZZ] why do we require current tab for "find everywhere" and "replace everywhere"?
-            //      todo: understand and refactor
-            //
-            // [ZZ] note: if we want CURRENT_*, error out if no active tab.
-            FindReplaceOptions singlesearchoptions = new FindReplaceOptions(options) { SearchMode = FindReplaceSearchMode.CURRENT_FILE };
+            FindReplaceOptions singlesearchoptions = new FindReplaceOptions(options)
+			{
+				SearchMode = FindReplaceSearchMode.CURRENT_FILE,
+				WrapAroundDisabled = true
+			};
             List<ScriptDocumentTab> rtabs = new List<ScriptDocumentTab>();
+
             switch (options.SearchMode)
             {
-                // we really need a bitfield here. Whatever.
                 case FindReplaceSearchMode.CURRENT_FILE:
                     if (ActiveTab == null)
                         return 0;
@@ -311,41 +310,21 @@ namespace CodeImp.DoomBuilder.Controls
 
                 case FindReplaceSearchMode.OPENED_TABS_ALL_SCRIPT_TYPES:
                     foreach (ScriptDocumentTab tab in tabs.TabPages)
-                    {
-                        if (options.SearchMode == FindReplaceSearchMode.OPENED_TABS_ALL_SCRIPT_TYPES ||
-                             tab.Config.ScriptType == ActiveTab.Config.ScriptType) rtabs.Add(tab);
-                    }
+                        rtabs.Add(tab);
                     break;
             }
 
             int replacements = 0;
             foreach (ScriptDocumentTab tab in rtabs)
-            {
-                // do find/replace in the current tab.
-                // make sure that we don't find the same thing twice in case replacement has part of it's value.
-                int firstPosition = -1;
-                int lengthDifference = options.ReplaceWith.Length - options.FindText.Length;
-                int lastSelectionStart = -1;
-                int lastSelectionEnd = -1;
-                while (true)
+			{
+				// Reset editor cursor to the start, searching until the end
+				tab.SelectionStart = tab.SelectionEnd = 0;
+
+				// Count the number of replacements made in this tab.
+				while (tab.FindNext(singlesearchoptions))
                 {
-                    if (!tab.FindNext(singlesearchoptions))
-                        break;
-                    if (firstPosition < 0)
-                        firstPosition = tab.SelectionStart;
-                    else if (tab.SelectionStart == firstPosition) // found the first
-                    {
-                        tab.SelectionStart = lastSelectionStart;
-                        tab.SelectionEnd = lastSelectionEnd;
-                        break;
-                    }
-                    if (tab.SelectionStart < firstPosition) // offset the first position with string length difference if we are replacing before it.
-                        firstPosition += lengthDifference;
-                    // do replacement
-                    tab.ReplaceSelection(options.ReplaceWith);
-                    //
-                    lastSelectionStart = tab.SelectionStart;
-                    lastSelectionEnd = tab.SelectionEnd;
+					tab.ReplaceSelection(options.ReplaceWith);
+
                     replacements++;
                 }
             }

--- a/Source/Core/Controls/Scripting/ScriptEditorPanel.cs
+++ b/Source/Core/Controls/Scripting/ScriptEditorPanel.cs
@@ -317,16 +317,19 @@ namespace CodeImp.DoomBuilder.Controls
             int replacements = 0;
             foreach (ScriptDocumentTab tab in rtabs)
 			{
-				// Reset editor cursor to the start, searching until the end
-				tab.SelectionStart = tab.SelectionEnd = 0;
+				tab.UndoTransaction(() =>
+				{
+					// Reset editor cursor to the start, searching until the end
+					tab.SelectionStart = tab.SelectionEnd = 0;
 
-				// Count the number of replacements made in this tab.
-				while (tab.FindNext(singlesearchoptions))
-                {
-					tab.ReplaceSelection(options.ReplaceWith);
+					// Count the number of replacements made in this tab.
+					while (tab.FindNext(singlesearchoptions))
+					{
+						tab.ReplaceSelection(options.ReplaceWith);
 
-                    replacements++;
-                }
+						replacements++;
+					}
+				});
             }
 
             return replacements;

--- a/Source/Core/Controls/Scripting/TextEditorControl.cs
+++ b/Source/Core/Controls/Scripting/TextEditorControl.cs
@@ -410,6 +410,8 @@ namespace ScintillaNET
 		public void IndicatorClearRange(int position, int length) { }
 		public void IndicatorFillRange(int position, int length) { }
 		public void EmptyUndoBuffer() { textbox.ClearUndo(); }
+		public void BeginUndoAction() { }
+		public void EndUndoAction() { }
 		public void Undo() { textbox.Undo(); }
 		public void Redo() { }
 		public void Cut() { textbox.Cut(); }

--- a/Source/Core/Windows/FindReplaceOptions.cs
+++ b/Source/Core/Windows/FindReplaceOptions.cs
@@ -33,6 +33,7 @@ namespace CodeImp.DoomBuilder.Windows
 		public bool WholeWord;
 		public string ReplaceWith;
 		public FindReplaceSearchMode SearchMode; //mxd
+		public bool WrapAroundDisabled;
 
 		//mxd. Copy constructor
 		public FindReplaceOptions(FindReplaceOptions other)
@@ -42,7 +43,7 @@ namespace CodeImp.DoomBuilder.Windows
 			WholeWord = other.WholeWord;
 			ReplaceWith = other.ReplaceWith;
 			SearchMode = other.SearchMode;
+			WrapAroundDisabled = other.WrapAroundDisabled;
 		}
 	}
 }
-

--- a/Source/Core/Windows/ScriptFindReplaceForm.cs
+++ b/Source/Core/Windows/ScriptFindReplaceForm.cs
@@ -308,18 +308,6 @@ namespace CodeImp.DoomBuilder.Windows
 			AddComboboxText(replacefindbox, options.FindText);
 			AddComboboxText(replacebox, options.ReplaceWith);
 
-			// Find next match
-            // [ZZ] why are we doing this? we aren't limited to the current tab.....
-            /*
-			ScriptDocumentTab curtab = editor.ActiveTab;
-			if(curtab == null || !curtab.FindNext(options, true))
-			{
-				editor.DisplayStatus(ScriptStatusType.Warning, "Can't find any occurrence of \"" + options.FindText + "\".");
-				return;
-			}*/
-
-            // Replace loop
-            // We don't really want to do this outside of the script editor.
             int replacements = editor.FindReplace(options);
 
 			// Show result
@@ -329,7 +317,7 @@ namespace CodeImp.DoomBuilder.Windows
 			}
 			else
 			{
-				editor.DisplayStatus(ScriptStatusType.Info, "Replaced " + replacements + " occurrences of \"" + options.FindText + "\" with \"" + options.ReplaceWith + "\".");
+				editor.DisplayStatus(ScriptStatusType.Info, "Replaced " + replacements + " occurrence" + (replacements == 1 ? "" : "s") + " of \"" + options.FindText + "\" with \"" + options.ReplaceWith + "\".");
 
                 // Find & select the last match on the now-current tab
                 ScriptDocumentTab curtab = editor.ActiveTab;


### PR DESCRIPTION
Follow-up to https://github.com/jewalky/UltimateDoomBuilder/issues/41 and commit https://github.com/jewalky/UltimateDoomBuilder/commit/123145085f54bc9c9fe93f4fd23779461ae62afd

The fix from 4 years ago covered the replacement being a substring at the start of the search phrase (`A(` -> `A("` or unchanged `A(` -> `A(`) but not if the partial match is at the end of the searched phrase.

e.g.,

```
search: redDoorOpened
replace: isRedDoorOpened (case-insensitive)
```

The `FindNext()` / `ReplaceSelection()` cycle in this case still goes into an infinite loop.

The fix started manually tracking selection ranges and the first replacement position, which could be any location in the script depending where the editor text cursor is.

Instead:

1. Before `FindNext()`, reset the editor's cursor to position 0 so the whole document is searched start to end.
2. Disable `FindNext()` wrap-around so the script text is only scanned once.

`ReplaceSelection()` always resets `editor.SelectionStart` to the character index just after the replacement so there isn't a need to manually track substring positions.