### PR TITLE
Add DeHackEd support

### DIFF
--- a/Build/Configurations/Boom_Doom2Doom.cfg
+++ b/Build/Configurations/Boom_Doom2Doom.cfg
@@ -64,3 +64,9 @@ enums
 	// Basic game enums
 	include("Includes\\Doom_misc.cfg", "enums");
 }
+
+// Dehacked data
+dehacked
+{
+  include("Includes\\Dehacked_Doom.cfg");
+}

--- a/Build/Configurations/Boom_DoomDoom.cfg
+++ b/Build/Configurations/Boom_DoomDoom.cfg
@@ -75,3 +75,9 @@ enums
 	// Basic game enums
 	include("Includes\\Doom_misc.cfg", "enums");
 }
+
+// Dehacked data
+dehacked
+{
+  include("Includes\\Dehacked_Doom.cfg");
+}

--- a/Build/Configurations/Doom_Doom2Doom.cfg
+++ b/Build/Configurations/Doom_Doom2Doom.cfg
@@ -63,3 +63,8 @@ enums
 	// Basic game enums
 	include("Includes\\Doom_misc.cfg", "enums");
 }
+
+dehacked
+{
+  include("Includes\\Dehacked_Doom.cfg");
+}

--- a/Build/Configurations/Doom_Doom2Doom.cfg
+++ b/Build/Configurations/Doom_Doom2Doom.cfg
@@ -64,6 +64,7 @@ enums
 	include("Includes\\Doom_misc.cfg", "enums");
 }
 
+// Dehacked data
 dehacked
 {
   include("Includes\\Dehacked_Doom.cfg");

--- a/Build/Configurations/Doom_DoomDoom.cfg
+++ b/Build/Configurations/Doom_DoomDoom.cfg
@@ -79,3 +79,9 @@ dehacked
 {
   include("Includes\\Dehacked_Doom.cfg");
 }
+
+// Dehacked data
+dehacked
+{
+  include("Includes\\Dehacked_Doom.cfg");
+}

--- a/Build/Configurations/Doom_DoomDoom.cfg
+++ b/Build/Configurations/Doom_DoomDoom.cfg
@@ -74,3 +74,8 @@ enums
 	// Basic game enums
 	include("Includes\\Doom_misc.cfg", "enums");
 }
+
+dehacked
+{
+  include("Includes\\Dehacked_Doom.cfg");
+}

--- a/Build/Configurations/Eternity_Doom2Doom.cfg
+++ b/Build/Configurations/Eternity_Doom2Doom.cfg
@@ -67,3 +67,9 @@ enums
 	// Basic game enums
 	include("Includes\\Doom_misc.cfg", "enums");
 }
+
+// Dehacked data
+dehacked
+{
+  include("Includes\\Dehacked_Doom.cfg");
+}

--- a/Build/Configurations/Eternity_DoomUDMF.cfg
+++ b/Build/Configurations/Eternity_DoomUDMF.cfg
@@ -55,3 +55,9 @@ enums
 	include("Includes\\ZDoom_misc.cfg", "enums_doom");
 	include("Includes\\Eternity_misc.cfg", "enums");
 }
+
+// Dehacked data
+dehacked
+{
+  include("Includes\\Dehacked_Doom.cfg");
+}

--- a/Build/Configurations/GZDoom_DoomDoom.cfg
+++ b/Build/Configurations/GZDoom_DoomDoom.cfg
@@ -65,3 +65,9 @@ enums
 	// Additional ZDoom enums for that game
 	include("Includes\\ZDoom_misc.cfg", "enums_doom");
 }
+
+// Dehacked data
+dehacked
+{
+  include("Includes\\Dehacked_Doom.cfg");
+}

--- a/Build/Configurations/GZDoom_DoomUDMF.cfg
+++ b/Build/Configurations/GZDoom_DoomUDMF.cfg
@@ -68,3 +68,9 @@ enums
 	// Additional ZDoom enums for that game
 	include("Includes\\ZDoom_misc.cfg", "enums_doom");
 }
+
+// Dehacked data
+dehacked
+{
+  include("Includes\\Dehacked_Doom.cfg");
+}

--- a/Build/Configurations/Includes/Dehacked_Doom.cfg
+++ b/Build/Configurations/Includes/Dehacked_Doom.cfg
@@ -1,0 +1,8501 @@
+things
+{
+	1
+	{
+		name = "Player";
+		height = 56;
+		width = 16;
+		initialframe = 149;
+		bits = 33557510;
+	}
+
+	2
+	{
+		name = "Trooper";
+		doomednum = 3004;
+		height = 56;
+		width = 20;
+		initialframe = 174;
+		bits = 4194310;
+	}
+
+	3
+	{
+		name = "Sargeant";
+		doomednum = 9;
+		height = 56;
+		width = 20;
+		initialframe = 207;
+		bits = 4194310;
+	}
+
+	4
+	{
+		name = "Archvile";
+		doomednum = 64;
+		height = 56;
+		width = 20;
+		initialframe = 241;
+		bits = 4194310;
+	}
+
+	5
+	{
+		name = "Archvile attack";
+		height = 16;
+		width = 20;
+		initialframe = 281;
+		bits = 2147484176;
+	}
+
+	6
+	{
+		name = "Revenant";
+		doomednum = 66;
+		height = 56;
+		width = 20;
+		initialframe = 321;
+		bits = 4194310;
+	}
+
+	7
+	{
+		name = "Revenant fireball";
+		height = 8;
+		width = 11;
+		initialframe = 316;
+		bits = 67088;
+	}
+
+	8
+	{
+		name = "Fireball trail";
+		height = 16;
+		width = 20;
+		initialframe = 311;
+		bits = 2147484176;
+	}
+
+	9
+	{
+		name = "Mancubus";
+		doomednum = 67;
+		height = 64;
+		width = 48;
+		initialframe = 362;
+		bits = 4194310;
+	}
+
+	10
+	{
+		name = "Mancubus fireball";
+		height = 8;
+		width = 6;
+		initialframe = 357;
+		bits = 2147550736;
+	}
+
+	11
+	{
+		name = "Chaingun Sargeant";
+		doomednum = 65;
+		height = 56;
+		width = 20;
+		initialframe = 406;
+		bits = 4194310;
+	}
+
+	12
+	{
+		name = "Imp";
+		doomednum = 3001;
+		height = 56;
+		width = 20;
+		initialframe = 442;
+		bits = 4194310;
+	}
+
+	13
+	{
+		name = "Demon";
+		doomednum = 3002;
+		height = 56;
+		width = 30;
+		initialframe = 475;
+		bits = 4194310;
+	}
+
+	14
+	{
+		name = "Spectre";
+		doomednum = 58;
+		height = 56;
+		width = 30;
+		initialframe = 475;
+		bits = 4456454;
+	}
+
+	15
+	{
+		name = "Cacodemon";
+		doomednum = 3005;
+		height = 56;
+		width = 31;
+		initialframe = 502;
+		bits = 4211206;
+	}
+
+	16
+	{
+		name = "Baron of Hell";
+		doomednum = 3003;
+		height = 64;
+		width = 24;
+		initialframe = 527;
+		bits = 4194310;
+	}
+
+	17
+	{
+		name = "Baron fireball";
+		height = 8;
+		width = 6;
+		initialframe = 522;
+		bits = 2147550736;
+	}
+
+	18
+	{
+		name = "Hell Knight";
+		doomednum = 69;
+		height = 64;
+		width = 24;
+		initialframe = 556;
+		bits = 4194310;
+	}
+
+	19
+	{
+		name = "Lost Soul";
+		doomednum = 3006;
+		height = 56;
+		width = 16;
+		initialframe = 585;
+		bits = 16902;
+	}
+
+	20
+	{
+		name = "Spiderdemon";
+		doomednum = 7;
+		height = 100;
+		width = 128;
+		initialframe = 601;
+		bits = 4194310;
+	}
+
+	21
+	{
+		name = "Arachnotron";
+		doomednum = 68;
+		height = 64;
+		width = 64;
+		initialframe = 632;
+		bits = 4194310;
+	}
+
+	22
+	{
+		name = "Cyberdemon";
+		doomednum = 16;
+		height = 110;
+		width = 40;
+		initialframe = 674;
+		bits = 4194310;
+	}
+
+	23
+	{
+		name = "Pain Elemental";
+		doomednum = 71;
+		height = 56;
+		width = 31;
+		initialframe = 701;
+		bits = 4211206;
+	}
+
+	24
+	{
+		name = "SS Nazi";
+		doomednum = 84;
+		height = 56;
+		width = 20;
+		initialframe = 726;
+		bits = 4194310;
+	}
+
+	25
+	{
+		name = "Commander Keen";
+		doomednum = 72;
+		height = 72;
+		width = 16;
+		initialframe = 763;
+		bits = 4195078;
+	}
+
+	26
+	{
+		name = "Big Brain";
+		doomednum = 88;
+		height = 16;
+		width = 16;
+		initialframe = 778;
+		bits = 6;
+	}
+
+	27
+	{
+		name = "Demon spawner";
+		doomednum = 89;
+		height = 32;
+		width = 20;
+		initialframe = 784;
+		bits = 24;
+	}
+
+	28
+	{
+		name = "Demon spawn spot";
+		doomednum = 87;
+		height = 32;
+		width = 20;
+		bits = 24;
+	}
+
+	29
+	{
+		name = "Demon spawn cube";
+		height = 32;
+		width = 6;
+		initialframe = 787;
+		bits = 71184;
+	}
+
+	30
+	{
+		name = "Demon spawn fire";
+		height = 16;
+		width = 20;
+		initialframe = 791;
+		bits = 2147484176;
+	}
+
+	31
+	{
+		name = "Barrel";
+		doomednum = 2035;
+		height = 42;
+		width = 10;
+		initialframe = 1076;
+		bits = 524294;
+	}
+
+	32
+	{
+		name = "Imp fireball";
+		height = 8;
+		width = 6;
+		initialframe = 97;
+		bits = 2147550736;
+	}
+
+	33
+	{
+		name = "Caco fireball";
+		height = 8;
+		width = 6;
+		initialframe = 102;
+		bits = 2147550736;
+	}
+
+	34
+	{
+		name = "Rocket in flight";
+		height = 8;
+		width = 11;
+		initialframe = 114;
+		bits = 67088;
+	}
+
+	35
+	{
+		name = "Plasma projectile";
+		height = 8;
+		width = 13;
+		initialframe = 107;
+		bits = 2147550736;
+	}
+
+	36
+	{
+		name = "BFG projectile";
+		height = 8;
+		width = 13;
+		initialframe = 115;
+		bits = 2147550736;
+	}
+
+	37
+	{
+		name = "Arachnotron projectile";
+		height = 8;
+		width = 13;
+		initialframe = 667;
+		bits = 2147550736;
+	}
+
+	38
+	{
+		name = "Bullet puff";
+		height = 16;
+		width = 20;
+		initialframe = 93;
+		bits = 2147484176;
+	}
+
+	39
+	{
+		name = "Blood splat";
+		height = 16;
+		width = 20;
+		initialframe = 90;
+		bits = 16;
+	}
+
+	40
+	{
+		name = "Teleport fog";
+		height = 16;
+		width = 20;
+		initialframe = 130;
+		bits = 2147484176;
+	}
+
+	41
+	{
+		name = "Item respawn fog";
+		height = 16;
+		width = 20;
+		initialframe = 142;
+		bits = 2147484176;
+	}
+
+	42
+	{
+		name = "Teleport exit";
+		doomednum = 14;
+		height = 16;
+		width = 20;
+		bits = 24;
+	}
+
+	43
+	{
+		name = "BFG impact";
+		height = 16;
+		width = 20;
+		initialframe = 123;
+		bits = 528;
+	}
+
+	44
+	{
+		name = "Green armor";
+		doomednum = 2018;
+		height = 16;
+		width = 20;
+		initialframe = 802;
+		bits = 1;
+	}
+
+	45
+	{
+		name = "Blue armor";
+		doomednum = 2019;
+		height = 16;
+		width = 20;
+		initialframe = 804;
+		bits = 1;
+	}
+
+	46
+	{
+		name = "Health potion";
+		doomednum = 2014;
+		height = 16;
+		width = 20;
+		initialframe = 816;
+		bits = 8388609;
+	}
+
+	47
+	{
+		name = "Armor helmet";
+		doomednum = 2015;
+		height = 16;
+		width = 20;
+		initialframe = 822;
+		bits = 8388609;
+	}
+
+	48
+	{
+		name = "Blue keycard";
+		doomednum = 5;
+		height = 16;
+		width = 20;
+		initialframe = 828;
+		bits = 33554433;
+	}
+
+	49
+	{
+		name = "Red keycard";
+		doomednum = 13;
+		height = 16;
+		width = 20;
+		initialframe = 830;
+		bits = 33554433;
+	}
+
+	50
+	{
+		name = "Yellow keycard";
+		doomednum = 6;
+		height = 16;
+		width = 20;
+		initialframe = 832;
+		bits = 33554433;
+	}
+
+	51
+	{
+		name = "Yellow skull key";
+		doomednum = 39;
+		height = 16;
+		width = 20;
+		initialframe = 838;
+		bits = 33554433;
+	}
+
+	52
+	{
+		name = "Red skull key";
+		doomednum = 38;
+		height = 16;
+		width = 20;
+		initialframe = 836;
+		bits = 33554433;
+	}
+
+	53
+	{
+		name = "Blue skull key";
+		doomednum = 40;
+		height = 16;
+		width = 20;
+		initialframe = 834;
+		bits = 33554433;
+	}
+
+	54
+	{
+		name = "Stimpack";
+		doomednum = 2011;
+		height = 16;
+		width = 20;
+		initialframe = 840;
+		bits = 1;
+	}
+
+	55
+	{
+		name = "Medical kit";
+		doomednum = 2012;
+		height = 16;
+		width = 20;
+		initialframe = 841;
+		bits = 1;
+	}
+
+	56
+	{
+		name = "Soul sphere";
+		doomednum = 2013;
+		height = 16;
+		width = 20;
+		initialframe = 842;
+		bits = 2155872257;
+	}
+
+	57
+	{
+		name = "Invulnerability";
+		doomednum = 2022;
+		height = 16;
+		width = 20;
+		initialframe = 848;
+		bits = 2155872257;
+	}
+
+	58
+	{
+		name = "Berserk sphere";
+		doomednum = 2023;
+		height = 16;
+		width = 20;
+		initialframe = 852;
+		bits = 8388609;
+	}
+
+	59
+	{
+		name = "Blur sphere";
+		doomednum = 2024;
+		height = 16;
+		width = 20;
+		initialframe = 853;
+		bits = 2155872257;
+	}
+
+	60
+	{
+		name = "Radiation suit";
+		doomednum = 2025;
+		height = 16;
+		width = 20;
+		initialframe = 861;
+		bits = 1;
+	}
+
+	61
+	{
+		name = "Computer map";
+		doomednum = 2026;
+		height = 16;
+		width = 20;
+		initialframe = 862;
+		bits = 8388609;
+	}
+
+	62
+	{
+		name = "Light amplification visor";
+		doomednum = 2045;
+		height = 16;
+		width = 20;
+		initialframe = 868;
+		bits = 8388609;
+	}
+
+	63
+	{
+		name = "Mega sphere";
+		doomednum = 83;
+		height = 16;
+		width = 20;
+		initialframe = 857;
+		bits = 2155872257;
+	}
+
+	64
+	{
+		name = "Ammo clip";
+		doomednum = 2007;
+		height = 16;
+		width = 20;
+		initialframe = 870;
+		bits = 1;
+	}
+
+	65
+	{
+		name = "Box of ammo";
+		doomednum = 2048;
+		height = 16;
+		width = 20;
+		initialframe = 871;
+		bits = 1;
+	}
+
+	66
+	{
+		name = "Rocket";
+		doomednum = 2010;
+		height = 16;
+		width = 20;
+		initialframe = 872;
+		bits = 1;
+	}
+
+	67
+	{
+		name = "Box of rockets";
+		doomednum = 2046;
+		height = 16;
+		width = 20;
+		initialframe = 873;
+		bits = 1;
+	}
+
+	68
+	{
+		name = "Energy cell";
+		doomednum = 2047;
+		height = 16;
+		width = 20;
+		initialframe = 874;
+		bits = 1;
+	}
+
+	69
+	{
+		name = "Energy cell pack";
+		doomednum = 17;
+		height = 16;
+		width = 20;
+		initialframe = 875;
+		bits = 1;
+	}
+
+	70
+	{
+		name = "Shells";
+		doomednum = 2008;
+		height = 16;
+		width = 20;
+		initialframe = 876;
+		bits = 1;
+	}
+
+	71
+	{
+		name = "Box of shells";
+		doomednum = 2049;
+		height = 16;
+		width = 20;
+		initialframe = 877;
+		bits = 1;
+	}
+
+	72
+	{
+		name = "Backpack";
+		doomednum = 8;
+		height = 16;
+		width = 20;
+		initialframe = 878;
+		bits = 1;
+	}
+
+	73
+	{
+		name = "BFG 9000";
+		doomednum = 2006;
+		height = 16;
+		width = 20;
+		initialframe = 879;
+		bits = 1;
+	}
+
+	74
+	{
+		name = "Chaingun";
+		doomednum = 2002;
+		height = 16;
+		width = 20;
+		initialframe = 880;
+		bits = 1;
+	}
+
+	75
+	{
+		name = "Chainsaw";
+		doomednum = 2005;
+		height = 16;
+		width = 20;
+		initialframe = 881;
+		bits = 1;
+	}
+
+	76
+	{
+		name = "Rocket launcher";
+		doomednum = 2003;
+		height = 16;
+		width = 20;
+		initialframe = 882;
+		bits = 1;
+	}
+
+	77
+	{
+		name = "Plasma rifle";
+		doomednum = 2004;
+		height = 16;
+		width = 20;
+		initialframe = 883;
+		bits = 1;
+	}
+
+	78
+	{
+		name = "Shotgun";
+		doomednum = 2001;
+		height = 16;
+		width = 20;
+		initialframe = 884;
+		bits = 1;
+	}
+
+	79
+	{
+		name = "Super shotgun";
+		doomednum = 82;
+		height = 16;
+		width = 20;
+		initialframe = 885;
+		bits = 1;
+	}
+
+	80
+	{
+		name = "Tall lamp";
+		doomednum = 85;
+		height = 16;
+		width = 16;
+		initialframe = 959;
+		bits = 2;
+	}
+
+	81
+	{
+		name = "Tall lamp 2";
+		doomednum = 86;
+		height = 16;
+		width = 16;
+		initialframe = 963;
+		bits = 2;
+	}
+
+	82
+	{
+		name = "Short lamp";
+		doomednum = 2028;
+		height = 16;
+		width = 16;
+		initialframe = 886;
+		bits = 2;
+	}
+
+	83
+	{
+		name = "Tall green pillar";
+		doomednum = 30;
+		height = 16;
+		width = 16;
+		initialframe = 907;
+		bits = 2;
+	}
+
+	84
+	{
+		name = "Short green pillar";
+		doomednum = 31;
+		height = 16;
+		width = 16;
+		initialframe = 908;
+		bits = 2;
+	}
+
+	85
+	{
+		name = "Tall red pillar";
+		doomednum = 32;
+		height = 16;
+		width = 16;
+		initialframe = 909;
+		bits = 2;
+	}
+
+	86
+	{
+		name = "Short red pillar";
+		doomednum = 33;
+		height = 16;
+		width = 16;
+		initialframe = 910;
+		bits = 2;
+	}
+
+	87
+	{
+		name = "Pillar with skull";
+		doomednum = 37;
+		height = 16;
+		width = 16;
+		initialframe = 913;
+		bits = 2;
+	}
+
+	88
+	{
+		name = "Pillar with heart";
+		doomednum = 36;
+		height = 16;
+		width = 16;
+		initialframe = 924;
+		bits = 2;
+	}
+
+	89
+	{
+		name = "Eye in symbol";
+		doomednum = 41;
+		height = 16;
+		width = 16;
+		initialframe = 917;
+		bits = 2;
+	}
+
+	90
+	{
+		name = "Flaming skulls";
+		doomednum = 42;
+		height = 16;
+		width = 16;
+		initialframe = 921;
+		bits = 2;
+	}
+
+	91
+	{
+		name = "Grey tree";
+		doomednum = 43;
+		height = 16;
+		width = 16;
+		initialframe = 914;
+		bits = 2;
+	}
+
+	92
+	{
+		name = "Tall blue torch";
+		doomednum = 44;
+		height = 16;
+		width = 16;
+		initialframe = 926;
+		bits = 2;
+	}
+
+	93
+	{
+		name = "Tall green torch";
+		doomednum = 45;
+		height = 16;
+		width = 16;
+		initialframe = 930;
+		bits = 2;
+	}
+
+	94
+	{
+		name = "Tall red torch";
+		doomednum = 46;
+		height = 16;
+		width = 16;
+		initialframe = 934;
+		bits = 2;
+	}
+
+	95
+	{
+		name = "Small blue torch";
+		doomednum = 55;
+		height = 16;
+		width = 16;
+		initialframe = 938;
+		bits = 2;
+	}
+
+	96
+	{
+		name = "Small green torch";
+		doomednum = 56;
+		height = 16;
+		width = 16;
+		initialframe = 942;
+		bits = 2;
+	}
+
+	97
+	{
+		name = "Small red torch";
+		doomednum = 57;
+		height = 16;
+		width = 16;
+		initialframe = 946;
+		bits = 2;
+	}
+
+	98
+	{
+		name = "Brown stub";
+		doomednum = 47;
+		height = 16;
+		width = 16;
+		initialframe = 906;
+		bits = 2;
+	}
+
+	99
+	{
+		name = "Technical column";
+		doomednum = 48;
+		height = 16;
+		width = 16;
+		initialframe = 916;
+		bits = 2;
+	}
+
+	100
+	{
+		name = "Candle";
+		doomednum = 34;
+		height = 16;
+		width = 20;
+		initialframe = 911;
+	}
+
+	101
+	{
+		name = "Candelabra";
+		doomednum = 35;
+		height = 16;
+		width = 16;
+		initialframe = 912;
+		bits = 2;
+	}
+
+	102
+	{
+		name = "Swaying body";
+		doomednum = 49;
+		height = 68;
+		width = 16;
+		initialframe = 888;
+		bits = 770;
+	}
+
+	103
+	{
+		name = "Hanging arms out";
+		doomednum = 50;
+		height = 84;
+		width = 16;
+		initialframe = 902;
+		bits = 770;
+	}
+
+	104
+	{
+		name = "One-legged body";
+		doomednum = 51;
+		height = 84;
+		width = 16;
+		initialframe = 903;
+		bits = 770;
+	}
+
+	105
+	{
+		name = "Hanging torso";
+		doomednum = 52;
+		height = 68;
+		width = 16;
+		initialframe = 904;
+		bits = 770;
+	}
+
+	106
+	{
+		name = "Hanging leg";
+		doomednum = 53;
+		height = 52;
+		width = 16;
+		initialframe = 905;
+		bits = 770;
+	}
+
+	107
+	{
+		name = "Hanging arms out 2";
+		doomednum = 59;
+		height = 84;
+		width = 20;
+		initialframe = 902;
+		bits = 768;
+	}
+
+	108
+	{
+		name = "Hanging torso 2";
+		doomednum = 60;
+		height = 68;
+		width = 20;
+		initialframe = 904;
+		bits = 768;
+	}
+
+	109
+	{
+		name = "One-legged body 2";
+		doomednum = 61;
+		height = 52;
+		width = 20;
+		initialframe = 903;
+		bits = 768;
+	}
+
+	110
+	{
+		name = "Hanging leg 2";
+		doomednum = 62;
+		height = 52;
+		width = 20;
+		initialframe = 905;
+		bits = 768;
+	}
+
+	111
+	{
+		name = "Swaying body 2";
+		doomednum = 63;
+		height = 68;
+		width = 20;
+		initialframe = 888;
+		bits = 768;
+	}
+
+	112
+	{
+		name = "Dead Cacodemon";
+		doomednum = 22;
+		height = 16;
+		width = 20;
+		initialframe = 515;
+	}
+
+	113
+	{
+		name = "Dead Marine";
+		doomednum = 15;
+		height = 16;
+		width = 20;
+		initialframe = 164;
+	}
+
+	114
+	{
+		name = "Dead Trooper";
+		doomednum = 18;
+		height = 16;
+		width = 20;
+		initialframe = 193;
+	}
+
+	115
+	{
+		name = "Dead Demon";
+		doomednum = 21;
+		height = 16;
+		width = 20;
+		initialframe = 495;
+	}
+
+	116
+	{
+		name = "Dead Lost Soul";
+		doomednum = 23;
+		height = 16;
+		width = 20;
+		initialframe = 600;
+	}
+
+	117
+	{
+		name = "Dead Imp";
+		doomednum = 20;
+		height = 16;
+		width = 20;
+		initialframe = 461;
+	}
+
+	118
+	{
+		name = "Dead Sargeant";
+		doomednum = 19;
+		height = 16;
+		width = 20;
+		initialframe = 226;
+	}
+
+	119
+	{
+		name = "Guts and bones";
+		doomednum = 10;
+		height = 16;
+		width = 20;
+		initialframe = 173;
+	}
+
+	120
+	{
+		name = "Guts and bones 2";
+		doomednum = 12;
+		height = 16;
+		width = 20;
+		initialframe = 173;
+	}
+
+	121
+	{
+		name = "Skewered heads";
+		doomednum = 28;
+		height = 16;
+		width = 16;
+		initialframe = 894;
+		bits = 2;
+	}
+
+	122
+	{
+		name = "Pool of blood";
+		doomednum = 24;
+		height = 16;
+		width = 20;
+		initialframe = 895;
+	}
+
+	123
+	{
+		name = "Pole with skull";
+		doomednum = 27;
+		height = 16;
+		width = 16;
+		initialframe = 896;
+		bits = 2;
+	}
+
+	124
+	{
+		name = "Pile of skulls";
+		doomednum = 29;
+		height = 16;
+		width = 16;
+		initialframe = 897;
+		bits = 2;
+	}
+
+	125
+	{
+		name = "Impaled body";
+		doomednum = 25;
+		height = 16;
+		width = 16;
+		initialframe = 899;
+		bits = 2;
+	}
+
+	126
+	{
+		name = "Twitching body";
+		doomednum = 26;
+		height = 16;
+		width = 16;
+		initialframe = 900;
+		bits = 2;
+	}
+
+	127
+	{
+		name = "Large tree";
+		doomednum = 54;
+		height = 16;
+		width = 32;
+		initialframe = 915;
+		bits = 2;
+	}
+
+	128
+	{
+		name = "Flaming barrel";
+		doomednum = 70;
+		height = 16;
+		width = 16;
+		initialframe = 813;
+		bits = 2;
+	}
+
+	129
+	{
+		name = "Hanging body 1";
+		doomednum = 73;
+		height = 88;
+		width = 16;
+		initialframe = 950;
+		bits = 770;
+	}
+
+	130
+	{
+		name = "Hanging body 2";
+		doomednum = 74;
+		height = 88;
+		width = 16;
+		initialframe = 951;
+		bits = 770;
+	}
+
+	131
+	{
+		name = "Hanging body 3";
+		doomednum = 75;
+		height = 64;
+		width = 16;
+		initialframe = 952;
+		bits = 770;
+	}
+
+	132
+	{
+		name = "Hanging body 4";
+		doomednum = 76;
+		height = 64;
+		width = 16;
+		initialframe = 953;
+		bits = 770;
+	}
+
+	133
+	{
+		name = "Hanging body 5";
+		doomednum = 77;
+		height = 64;
+		width = 16;
+		initialframe = 954;
+		bits = 770;
+	}
+
+	134
+	{
+		name = "Hanging body 6";
+		doomednum = 78;
+		height = 64;
+		width = 16;
+		initialframe = 955;
+		bits = 770;
+	}
+
+	135
+	{
+		name = "Pool of blood 1";
+		doomednum = 79;
+		height = 16;
+		width = 20;
+		initialframe = 956;
+		bits = 16;
+	}
+
+	136
+	{
+		name = "Pool of blood 2";
+		doomednum = 80;
+		height = 16;
+		width = 20;
+		initialframe = 957;
+		bits = 16;
+	}
+
+	137
+	{
+		name = "Brain";
+		doomednum = 81;
+		height = 16;
+		width = 20;
+		initialframe = 958;
+		bits = 16;
+	}
+
+	138
+	{
+		name = "Pusher";
+		doomednum = 5001;
+		height = 0;
+		width = 0;
+		initialframe = 967;
+		bits = 16;
+	}
+
+	139
+	{
+		name = "Puller";
+		doomednum = 5002;
+		height = 0;
+		width = 0;
+		initialframe = 967;
+		bits = 16;
+	}
+
+	140
+	{
+		name = "Dog";
+		doomednum = 888;
+		height = 28;
+		width = 11;
+		initialframe = 972;
+		bits = 4194310;
+	}
+
+	141
+	{
+		name = "Beta Plasma 1";
+		height = 8;
+		width = 13;
+		initialframe = 1042;
+		bits = 536938000;
+	}
+
+	142
+	{
+		name = "Beta Plasma 2";
+		height = 8;
+		width = 6;
+		initialframe = 1049;
+		bits = 536938000;
+	}
+
+	143
+	{
+		name = "Beta Sceptre";
+		doomednum = 2016;
+		height = 16;
+		width = 10;
+		initialframe = 1054;
+		bits = 8388609;
+	}
+
+	144
+	{
+		name = "Beta Bible";
+		doomednum = 2017;
+		height = 10;
+		width = 20;
+		initialframe = 1055;
+		bits = 8388609;
+	}
+
+	145
+	{
+		name = "Music Source";
+	}
+
+	146
+	{
+		name = "MT_GIBDTH";
+	}
+
+	147
+	{
+		name = "MT_BLUEBLOOD";
+	}
+
+	148
+	{
+		name = "MT_GREENBLOOD";
+	}
+
+	149
+	{
+		name = "MT_FUZZYBLOOD";
+	}
+
+	150
+	{
+		name = "MT_TRAIL";
+	}
+
+	151
+	{
+		name = "Extra thing 0";
+	}
+
+	152
+	{
+		name = "Extra thing 1";
+	}
+
+	153
+	{
+		name = "Extra thing 2";
+	}
+
+	154
+	{
+		name = "Extra thing 3";
+	}
+
+	155
+	{
+		name = "Extra thing 4";
+	}
+
+	156
+	{
+		name = "Extra thing 5";
+	}
+
+	157
+	{
+		name = "Extra thing 6";
+	}
+
+	158
+	{
+		name = "Extra thing 7";
+	}
+
+	159
+	{
+		name = "Extra thing 8";
+	}
+
+	160
+	{
+		name = "Extra thing 9";
+	}
+
+	161
+	{
+		name = "Extra thing 10";
+	}
+
+	162
+	{
+		name = "Extra thing 11";
+	}
+
+	163
+	{
+		name = "Extra thing 12";
+	}
+
+	164
+	{
+		name = "Extra thing 13";
+	}
+
+	165
+	{
+		name = "Extra thing 14";
+	}
+
+	166
+	{
+		name = "Extra thing 15";
+	}
+
+	167
+	{
+		name = "Extra thing 16";
+	}
+
+	168
+	{
+		name = "Extra thing 17";
+	}
+
+	169
+	{
+		name = "Extra thing 18";
+	}
+
+	170
+	{
+		name = "Extra thing 19";
+	}
+
+	171
+	{
+		name = "Extra thing 20";
+	}
+
+	172
+	{
+		name = "Extra thing 21";
+	}
+
+	173
+	{
+		name = "Extra thing 22";
+	}
+
+	174
+	{
+		name = "Extra thing 23";
+	}
+
+	175
+	{
+		name = "Extra thing 24";
+	}
+
+	176
+	{
+		name = "Extra thing 25";
+	}
+
+	177
+	{
+		name = "Extra thing 26";
+	}
+
+	178
+	{
+		name = "Extra thing 27";
+	}
+
+	179
+	{
+		name = "Extra thing 28";
+	}
+
+	180
+	{
+		name = "Extra thing 29";
+	}
+
+	181
+	{
+		name = "Extra thing 30";
+	}
+
+	182
+	{
+		name = "Extra thing 31";
+	}
+
+	183
+	{
+		name = "Extra thing 32";
+	}
+
+	184
+	{
+		name = "Extra thing 33";
+	}
+
+	185
+	{
+		name = "Extra thing 34";
+	}
+
+	186
+	{
+		name = "Extra thing 35";
+	}
+
+	187
+	{
+		name = "Extra thing 36";
+	}
+
+	188
+	{
+		name = "Extra thing 37";
+	}
+
+	189
+	{
+		name = "Extra thing 38";
+	}
+
+	190
+	{
+		name = "Extra thing 39";
+	}
+
+	191
+	{
+		name = "Extra thing 40";
+	}
+
+	192
+	{
+		name = "Extra thing 41";
+	}
+
+	193
+	{
+		name = "Extra thing 42";
+	}
+
+	194
+	{
+		name = "Extra thing 43";
+	}
+
+	195
+	{
+		name = "Extra thing 44";
+	}
+
+	196
+	{
+		name = "Extra thing 45";
+	}
+
+	197
+	{
+		name = "Extra thing 46";
+	}
+
+	198
+	{
+		name = "Extra thing 47";
+	}
+
+	199
+	{
+		name = "Extra thing 48";
+	}
+
+	200
+	{
+		name = "Extra thing 49";
+	}
+
+	201
+	{
+		name = "Extra thing 50";
+	}
+
+	202
+	{
+		name = "Extra thing 51";
+	}
+
+	203
+	{
+		name = "Extra thing 52";
+	}
+
+	204
+	{
+		name = "Extra thing 53";
+	}
+
+	205
+	{
+		name = "Extra thing 54";
+	}
+
+	206
+	{
+		name = "Extra thing 55";
+	}
+
+	207
+	{
+		name = "Extra thing 56";
+	}
+
+	208
+	{
+		name = "Extra thing 57";
+	}
+
+	209
+	{
+		name = "Extra thing 58";
+	}
+
+	210
+	{
+		name = "Extra thing 59";
+	}
+
+	211
+	{
+		name = "Extra thing 60";
+	}
+
+	212
+	{
+		name = "Extra thing 61";
+	}
+
+	213
+	{
+		name = "Extra thing 62";
+	}
+
+	214
+	{
+		name = "Extra thing 63";
+	}
+
+	215
+	{
+		name = "Extra thing 64";
+	}
+
+	216
+	{
+		name = "Extra thing 65";
+	}
+
+	217
+	{
+		name = "Extra thing 66";
+	}
+
+	218
+	{
+		name = "Extra thing 67";
+	}
+
+	219
+	{
+		name = "Extra thing 68";
+	}
+
+	220
+	{
+		name = "Extra thing 69";
+	}
+
+	221
+	{
+		name = "Extra thing 70";
+	}
+
+	222
+	{
+		name = "Extra thing 71";
+	}
+
+	223
+	{
+		name = "Extra thing 72";
+	}
+
+	224
+	{
+		name = "Extra thing 73";
+	}
+
+	225
+	{
+		name = "Extra thing 74";
+	}
+
+	226
+	{
+		name = "Extra thing 75";
+	}
+
+	227
+	{
+		name = "Extra thing 76";
+	}
+
+	228
+	{
+		name = "Extra thing 77";
+	}
+
+	229
+	{
+		name = "Extra thing 78";
+	}
+
+	230
+	{
+		name = "Extra thing 79";
+	}
+
+	231
+	{
+		name = "Extra thing 80";
+	}
+
+	232
+	{
+		name = "Extra thing 81";
+	}
+
+	233
+	{
+		name = "Extra thing 82";
+	}
+
+	234
+	{
+		name = "Extra thing 83";
+	}
+
+	235
+	{
+		name = "Extra thing 84";
+	}
+
+	236
+	{
+		name = "Extra thing 85";
+	}
+
+	237
+	{
+		name = "Extra thing 86";
+	}
+
+	238
+	{
+		name = "Extra thing 87";
+	}
+
+	239
+	{
+		name = "Extra thing 88";
+	}
+
+	240
+	{
+		name = "Extra thing 89";
+	}
+
+	241
+	{
+		name = "Extra thing 90";
+	}
+
+	242
+	{
+		name = "Extra thing 91";
+	}
+
+	243
+	{
+		name = "Extra thing 92";
+	}
+
+	244
+	{
+		name = "Extra thing 93";
+	}
+
+	245
+	{
+		name = "Extra thing 94";
+	}
+
+	246
+	{
+		name = "Extra thing 95";
+	}
+
+	247
+	{
+		name = "Extra thing 96";
+	}
+
+	248
+	{
+		name = "Extra thing 97";
+	}
+
+	249
+	{
+		name = "Extra thing 98";
+	}
+
+	250
+	{
+		name = "Extra thing 99";
+	}
+
+}
+
+
+frames
+{
+	// WhackEd defaults to 138
+	default
+	{
+		spritenumber = 138;
+	}
+
+	0
+	{
+		spritenumber = 0;
+	}
+
+	1
+	{
+		spritenumber = 1;
+		spritesubnumber = 4;
+	}
+
+	2
+	{
+		spritenumber = 2;
+	}
+
+	3
+	{
+		spritenumber = 2;
+	}
+
+	4
+	{
+		spritenumber = 2;
+	}
+
+	5
+	{
+		spritenumber = 2;
+		spritesubnumber = 1;
+	}
+
+	6
+	{
+		spritenumber = 2;
+		spritesubnumber = 2;
+	}
+
+	7
+	{
+		spritenumber = 2;
+		spritesubnumber = 3;
+	}
+
+	8
+	{
+		spritenumber = 2;
+		spritesubnumber = 2;
+	}
+
+	9
+	{
+		spritenumber = 2;
+		spritesubnumber = 1;
+	}
+
+	10
+	{
+		spritenumber = 3;
+	}
+
+	11
+	{
+		spritenumber = 3;
+	}
+
+	12
+	{
+		spritenumber = 3;
+	}
+
+	13
+	{
+		spritenumber = 3;
+	}
+
+	14
+	{
+		spritenumber = 3;
+		spritesubnumber = 1;
+	}
+
+	15
+	{
+		spritenumber = 3;
+		spritesubnumber = 2;
+	}
+
+	16
+	{
+		spritenumber = 3;
+		spritesubnumber = 1;
+	}
+
+	17
+	{
+		spritenumber = 4;
+	}
+
+	18
+	{
+		spritenumber = 1;
+	}
+
+	19
+	{
+		spritenumber = 1;
+	}
+
+	20
+	{
+		spritenumber = 1;
+	}
+
+	21
+	{
+		spritenumber = 1;
+	}
+
+	22
+	{
+		spritenumber = 1;
+	}
+
+	23
+	{
+		spritenumber = 1;
+		spritesubnumber = 1;
+	}
+
+	24
+	{
+		spritenumber = 1;
+		spritesubnumber = 2;
+	}
+
+	25
+	{
+		spritenumber = 1;
+		spritesubnumber = 3;
+	}
+
+	26
+	{
+		spritenumber = 1;
+		spritesubnumber = 2;
+	}
+
+	27
+	{
+		spritenumber = 1;
+		spritesubnumber = 1;
+	}
+
+	28
+	{
+		spritenumber = 1;
+	}
+
+	29
+	{
+		spritenumber = 1;
+	}
+
+	30
+	{
+		spritenumber = 5;
+	}
+
+	31
+	{
+		spritenumber = 5;
+		spritesubnumber = 1;
+	}
+
+	32
+	{
+		spritenumber = 6;
+	}
+
+	33
+	{
+		spritenumber = 6;
+	}
+
+	34
+	{
+		spritenumber = 6;
+	}
+
+	35
+	{
+		spritenumber = 6;
+	}
+
+	36
+	{
+		spritenumber = 6;
+	}
+
+	37
+	{
+		spritenumber = 6;
+		spritesubnumber = 1;
+	}
+
+	38
+	{
+		spritenumber = 6;
+		spritesubnumber = 2;
+	}
+
+	39
+	{
+		spritenumber = 6;
+		spritesubnumber = 3;
+	}
+
+	40
+	{
+		spritenumber = 6;
+		spritesubnumber = 4;
+	}
+
+	41
+	{
+		spritenumber = 6;
+		spritesubnumber = 5;
+	}
+
+	42
+	{
+		spritenumber = 6;
+		spritesubnumber = 6;
+	}
+
+	43
+	{
+		spritenumber = 6;
+		spritesubnumber = 7;
+	}
+
+	44
+	{
+		spritenumber = 6;
+	}
+
+	45
+	{
+		spritenumber = 6;
+		spritesubnumber = 1;
+	}
+
+	46
+	{
+		spritenumber = 6;
+	}
+
+	47
+	{
+		spritenumber = 6;
+		spritesubnumber = 8;
+	}
+
+	48
+	{
+		spritenumber = 6;
+		spritesubnumber = 9;
+	}
+
+	49
+	{
+		spritenumber = 7;
+	}
+
+	50
+	{
+		spritenumber = 7;
+	}
+
+	51
+	{
+		spritenumber = 7;
+	}
+
+	52
+	{
+		spritenumber = 7;
+	}
+
+	53
+	{
+		spritenumber = 7;
+		spritesubnumber = 1;
+	}
+
+	54
+	{
+		spritenumber = 7;
+		spritesubnumber = 1;
+	}
+
+	55
+	{
+		spritenumber = 8;
+	}
+
+	56
+	{
+		spritenumber = 8;
+		spritesubnumber = 1;
+	}
+
+	57
+	{
+		spritenumber = 9;
+	}
+
+	58
+	{
+		spritenumber = 9;
+	}
+
+	59
+	{
+		spritenumber = 9;
+	}
+
+	60
+	{
+		spritenumber = 9;
+		spritesubnumber = 1;
+	}
+
+	61
+	{
+		spritenumber = 9;
+		spritesubnumber = 1;
+	}
+
+	62
+	{
+		spritenumber = 9;
+		spritesubnumber = 1;
+	}
+
+	63
+	{
+		spritenumber = 10;
+	}
+
+	64
+	{
+		spritenumber = 10;
+		spritesubnumber = 1;
+	}
+
+	65
+	{
+		spritenumber = 10;
+		spritesubnumber = 2;
+	}
+
+	66
+	{
+		spritenumber = 10;
+		spritesubnumber = 3;
+	}
+
+	67
+	{
+		spritenumber = 11;
+		spritesubnumber = 2;
+	}
+
+	68
+	{
+		spritenumber = 11;
+		spritesubnumber = 3;
+	}
+
+	69
+	{
+		spritenumber = 11;
+		spritesubnumber = 2;
+	}
+
+	70
+	{
+		spritenumber = 11;
+		spritesubnumber = 2;
+	}
+
+	71
+	{
+		spritenumber = 11;
+	}
+
+	72
+	{
+		spritenumber = 11;
+		spritesubnumber = 1;
+	}
+
+	73
+	{
+		spritenumber = 11;
+		spritesubnumber = 1;
+	}
+
+	74
+	{
+		spritenumber = 12;
+	}
+
+	75
+	{
+		spritenumber = 12;
+	}
+
+	76
+	{
+		spritenumber = 12;
+	}
+
+	77
+	{
+		spritenumber = 12;
+	}
+
+	78
+	{
+		spritenumber = 12;
+		spritesubnumber = 1;
+	}
+
+	79
+	{
+		spritenumber = 13;
+	}
+
+	80
+	{
+		spritenumber = 13;
+		spritesubnumber = 1;
+	}
+
+	81
+	{
+		spritenumber = 14;
+	}
+
+	82
+	{
+		spritenumber = 14;
+	}
+
+	83
+	{
+		spritenumber = 14;
+	}
+
+	84
+	{
+		spritenumber = 14;
+	}
+
+	85
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	86
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	87
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	88
+	{
+		spritenumber = 15;
+	}
+
+	89
+	{
+		spritenumber = 15;
+		spritesubnumber = 1;
+	}
+
+	90
+	{
+		spritenumber = 16;
+		spritesubnumber = 2;
+	}
+
+	91
+	{
+		spritenumber = 16;
+		spritesubnumber = 1;
+	}
+
+	92
+	{
+		spritenumber = 16;
+	}
+
+	93
+	{
+		spritenumber = 17;
+	}
+
+	94
+	{
+		spritenumber = 17;
+		spritesubnumber = 1;
+	}
+
+	95
+	{
+		spritenumber = 17;
+		spritesubnumber = 2;
+	}
+
+	96
+	{
+		spritenumber = 17;
+		spritesubnumber = 3;
+	}
+
+	97
+	{
+		spritenumber = 18;
+	}
+
+	98
+	{
+		spritenumber = 18;
+		spritesubnumber = 1;
+	}
+
+	99
+	{
+		spritenumber = 18;
+		spritesubnumber = 2;
+	}
+
+	100
+	{
+		spritenumber = 18;
+		spritesubnumber = 3;
+	}
+
+	101
+	{
+		spritenumber = 18;
+		spritesubnumber = 4;
+	}
+
+	102
+	{
+		spritenumber = 19;
+	}
+
+	103
+	{
+		spritenumber = 19;
+		spritesubnumber = 1;
+	}
+
+	104
+	{
+		spritenumber = 19;
+		spritesubnumber = 2;
+	}
+
+	105
+	{
+		spritenumber = 19;
+		spritesubnumber = 3;
+	}
+
+	106
+	{
+		spritenumber = 19;
+		spritesubnumber = 4;
+	}
+
+	107
+	{
+		spritenumber = 20;
+	}
+
+	108
+	{
+		spritenumber = 20;
+		spritesubnumber = 1;
+	}
+
+	109
+	{
+		spritenumber = 21;
+	}
+
+	110
+	{
+		spritenumber = 21;
+		spritesubnumber = 1;
+	}
+
+	111
+	{
+		spritenumber = 21;
+		spritesubnumber = 2;
+	}
+
+	112
+	{
+		spritenumber = 21;
+		spritesubnumber = 3;
+	}
+
+	113
+	{
+		spritenumber = 21;
+		spritesubnumber = 4;
+	}
+
+	114
+	{
+		spritenumber = 22;
+	}
+
+	115
+	{
+		spritenumber = 23;
+	}
+
+	116
+	{
+		spritenumber = 23;
+		spritesubnumber = 1;
+	}
+
+	117
+	{
+		spritenumber = 24;
+	}
+
+	118
+	{
+		spritenumber = 24;
+		spritesubnumber = 1;
+	}
+
+	119
+	{
+		spritenumber = 24;
+		spritesubnumber = 2;
+	}
+
+	120
+	{
+		spritenumber = 24;
+		spritesubnumber = 3;
+	}
+
+	121
+	{
+		spritenumber = 24;
+		spritesubnumber = 4;
+	}
+
+	122
+	{
+		spritenumber = 24;
+		spritesubnumber = 5;
+	}
+
+	123
+	{
+		spritenumber = 25;
+	}
+
+	124
+	{
+		spritenumber = 25;
+		spritesubnumber = 1;
+	}
+
+	125
+	{
+		spritenumber = 25;
+		spritesubnumber = 2;
+	}
+
+	126
+	{
+		spritenumber = 25;
+		spritesubnumber = 3;
+	}
+
+	127
+	{
+		spritenumber = 22;
+		spritesubnumber = 1;
+	}
+
+	128
+	{
+		spritenumber = 22;
+		spritesubnumber = 2;
+	}
+
+	129
+	{
+		spritenumber = 22;
+		spritesubnumber = 3;
+	}
+
+	130
+	{
+		spritenumber = 26;
+	}
+
+	131
+	{
+		spritenumber = 26;
+		spritesubnumber = 1;
+	}
+
+	132
+	{
+		spritenumber = 26;
+	}
+
+	133
+	{
+		spritenumber = 26;
+		spritesubnumber = 1;
+	}
+
+	134
+	{
+		spritenumber = 26;
+		spritesubnumber = 2;
+	}
+
+	135
+	{
+		spritenumber = 26;
+		spritesubnumber = 3;
+	}
+
+	136
+	{
+		spritenumber = 26;
+		spritesubnumber = 4;
+	}
+
+	137
+	{
+		spritenumber = 26;
+		spritesubnumber = 5;
+	}
+
+	138
+	{
+		spritenumber = 26;
+		spritesubnumber = 6;
+	}
+
+	139
+	{
+		spritenumber = 26;
+		spritesubnumber = 7;
+	}
+
+	140
+	{
+		spritenumber = 26;
+		spritesubnumber = 8;
+	}
+
+	141
+	{
+		spritenumber = 26;
+		spritesubnumber = 9;
+	}
+
+	142
+	{
+		spritenumber = 27;
+	}
+
+	143
+	{
+		spritenumber = 27;
+		spritesubnumber = 1;
+	}
+
+	144
+	{
+		spritenumber = 27;
+	}
+
+	145
+	{
+		spritenumber = 27;
+		spritesubnumber = 1;
+	}
+
+	146
+	{
+		spritenumber = 27;
+		spritesubnumber = 2;
+	}
+
+	147
+	{
+		spritenumber = 27;
+		spritesubnumber = 3;
+	}
+
+	148
+	{
+		spritenumber = 27;
+		spritesubnumber = 4;
+	}
+
+	149
+	{
+		spritenumber = 28;
+	}
+
+	150
+	{
+		spritenumber = 28;
+	}
+
+	151
+	{
+		spritenumber = 28;
+		spritesubnumber = 1;
+	}
+
+	152
+	{
+		spritenumber = 28;
+		spritesubnumber = 2;
+	}
+
+	153
+	{
+		spritenumber = 28;
+		spritesubnumber = 3;
+	}
+
+	154
+	{
+		spritenumber = 28;
+		spritesubnumber = 4;
+	}
+
+	155
+	{
+		spritenumber = 28;
+		spritesubnumber = 5;
+	}
+
+	156
+	{
+		spritenumber = 28;
+		spritesubnumber = 6;
+	}
+
+	157
+	{
+		spritenumber = 28;
+		spritesubnumber = 6;
+	}
+
+	158
+	{
+		spritenumber = 28;
+		spritesubnumber = 7;
+	}
+
+	159
+	{
+		spritenumber = 28;
+		spritesubnumber = 8;
+	}
+
+	160
+	{
+		spritenumber = 28;
+		spritesubnumber = 9;
+	}
+
+	161
+	{
+		spritenumber = 28;
+		spritesubnumber = 10;
+	}
+
+	162
+	{
+		spritenumber = 28;
+		spritesubnumber = 11;
+	}
+
+	163
+	{
+		spritenumber = 28;
+		spritesubnumber = 12;
+	}
+
+	164
+	{
+		spritenumber = 28;
+		spritesubnumber = 13;
+	}
+
+	165
+	{
+		spritenumber = 28;
+		spritesubnumber = 14;
+	}
+
+	166
+	{
+		spritenumber = 28;
+		spritesubnumber = 15;
+	}
+
+	167
+	{
+		spritenumber = 28;
+		spritesubnumber = 16;
+	}
+
+	168
+	{
+		spritenumber = 28;
+		spritesubnumber = 17;
+	}
+
+	169
+	{
+		spritenumber = 28;
+		spritesubnumber = 18;
+	}
+
+	170
+	{
+		spritenumber = 28;
+		spritesubnumber = 19;
+	}
+
+	171
+	{
+		spritenumber = 28;
+		spritesubnumber = 20;
+	}
+
+	172
+	{
+		spritenumber = 28;
+		spritesubnumber = 21;
+	}
+
+	173
+	{
+		spritenumber = 28;
+		spritesubnumber = 22;
+	}
+
+	174
+	{
+		spritenumber = 29;
+	}
+
+	175
+	{
+		spritenumber = 29;
+		spritesubnumber = 1;
+	}
+
+	176
+	{
+		spritenumber = 29;
+	}
+
+	177
+	{
+		spritenumber = 29;
+	}
+
+	178
+	{
+		spritenumber = 29;
+		spritesubnumber = 1;
+	}
+
+	179
+	{
+		spritenumber = 29;
+		spritesubnumber = 1;
+	}
+
+	180
+	{
+		spritenumber = 29;
+		spritesubnumber = 2;
+	}
+
+	181
+	{
+		spritenumber = 29;
+		spritesubnumber = 2;
+	}
+
+	182
+	{
+		spritenumber = 29;
+		spritesubnumber = 3;
+	}
+
+	183
+	{
+		spritenumber = 29;
+		spritesubnumber = 3;
+	}
+
+	184
+	{
+		spritenumber = 29;
+		spritesubnumber = 4;
+	}
+
+	185
+	{
+		spritenumber = 29;
+		spritesubnumber = 5;
+	}
+
+	186
+	{
+		spritenumber = 29;
+		spritesubnumber = 4;
+	}
+
+	187
+	{
+		spritenumber = 29;
+		spritesubnumber = 6;
+	}
+
+	188
+	{
+		spritenumber = 29;
+		spritesubnumber = 6;
+	}
+
+	189
+	{
+		spritenumber = 29;
+		spritesubnumber = 7;
+	}
+
+	190
+	{
+		spritenumber = 29;
+		spritesubnumber = 8;
+	}
+
+	191
+	{
+		spritenumber = 29;
+		spritesubnumber = 9;
+	}
+
+	192
+	{
+		spritenumber = 29;
+		spritesubnumber = 10;
+	}
+
+	193
+	{
+		spritenumber = 29;
+		spritesubnumber = 11;
+	}
+
+	194
+	{
+		spritenumber = 29;
+		spritesubnumber = 12;
+	}
+
+	195
+	{
+		spritenumber = 29;
+		spritesubnumber = 13;
+	}
+
+	196
+	{
+		spritenumber = 29;
+		spritesubnumber = 14;
+	}
+
+	197
+	{
+		spritenumber = 29;
+		spritesubnumber = 15;
+	}
+
+	198
+	{
+		spritenumber = 29;
+		spritesubnumber = 16;
+	}
+
+	199
+	{
+		spritenumber = 29;
+		spritesubnumber = 17;
+	}
+
+	200
+	{
+		spritenumber = 29;
+		spritesubnumber = 18;
+	}
+
+	201
+	{
+		spritenumber = 29;
+		spritesubnumber = 19;
+	}
+
+	202
+	{
+		spritenumber = 29;
+		spritesubnumber = 20;
+	}
+
+	203
+	{
+		spritenumber = 29;
+		spritesubnumber = 10;
+	}
+
+	204
+	{
+		spritenumber = 29;
+		spritesubnumber = 9;
+	}
+
+	205
+	{
+		spritenumber = 29;
+		spritesubnumber = 8;
+	}
+
+	206
+	{
+		spritenumber = 29;
+		spritesubnumber = 7;
+	}
+
+	207
+	{
+		spritenumber = 30;
+	}
+
+	208
+	{
+		spritenumber = 30;
+		spritesubnumber = 1;
+	}
+
+	209
+	{
+		spritenumber = 30;
+	}
+
+	210
+	{
+		spritenumber = 30;
+	}
+
+	211
+	{
+		spritenumber = 30;
+		spritesubnumber = 1;
+	}
+
+	212
+	{
+		spritenumber = 30;
+		spritesubnumber = 1;
+	}
+
+	213
+	{
+		spritenumber = 30;
+		spritesubnumber = 2;
+	}
+
+	214
+	{
+		spritenumber = 30;
+		spritesubnumber = 2;
+	}
+
+	215
+	{
+		spritenumber = 30;
+		spritesubnumber = 3;
+	}
+
+	216
+	{
+		spritenumber = 30;
+		spritesubnumber = 3;
+	}
+
+	217
+	{
+		spritenumber = 30;
+		spritesubnumber = 4;
+	}
+
+	218
+	{
+		spritenumber = 30;
+		spritesubnumber = 5;
+	}
+
+	219
+	{
+		spritenumber = 30;
+		spritesubnumber = 4;
+	}
+
+	220
+	{
+		spritenumber = 30;
+		spritesubnumber = 6;
+	}
+
+	221
+	{
+		spritenumber = 30;
+		spritesubnumber = 6;
+	}
+
+	222
+	{
+		spritenumber = 30;
+		spritesubnumber = 7;
+	}
+
+	223
+	{
+		spritenumber = 30;
+		spritesubnumber = 8;
+	}
+
+	224
+	{
+		spritenumber = 30;
+		spritesubnumber = 9;
+	}
+
+	225
+	{
+		spritenumber = 30;
+		spritesubnumber = 10;
+	}
+
+	226
+	{
+		spritenumber = 30;
+		spritesubnumber = 11;
+	}
+
+	227
+	{
+		spritenumber = 30;
+		spritesubnumber = 12;
+	}
+
+	228
+	{
+		spritenumber = 30;
+		spritesubnumber = 13;
+	}
+
+	229
+	{
+		spritenumber = 30;
+		spritesubnumber = 14;
+	}
+
+	230
+	{
+		spritenumber = 30;
+		spritesubnumber = 15;
+	}
+
+	231
+	{
+		spritenumber = 30;
+		spritesubnumber = 16;
+	}
+
+	232
+	{
+		spritenumber = 30;
+		spritesubnumber = 17;
+	}
+
+	233
+	{
+		spritenumber = 30;
+		spritesubnumber = 18;
+	}
+
+	234
+	{
+		spritenumber = 30;
+		spritesubnumber = 19;
+	}
+
+	235
+	{
+		spritenumber = 30;
+		spritesubnumber = 20;
+	}
+
+	236
+	{
+		spritenumber = 30;
+		spritesubnumber = 11;
+	}
+
+	237
+	{
+		spritenumber = 30;
+		spritesubnumber = 10;
+	}
+
+	238
+	{
+		spritenumber = 30;
+		spritesubnumber = 9;
+	}
+
+	239
+	{
+		spritenumber = 30;
+		spritesubnumber = 8;
+	}
+
+	240
+	{
+		spritenumber = 30;
+		spritesubnumber = 7;
+	}
+
+	241
+	{
+		spritenumber = 31;
+	}
+
+	242
+	{
+		spritenumber = 31;
+		spritesubnumber = 1;
+	}
+
+	243
+	{
+		spritenumber = 31;
+	}
+
+	244
+	{
+		spritenumber = 31;
+	}
+
+	245
+	{
+		spritenumber = 31;
+		spritesubnumber = 1;
+	}
+
+	246
+	{
+		spritenumber = 31;
+		spritesubnumber = 1;
+	}
+
+	247
+	{
+		spritenumber = 31;
+		spritesubnumber = 2;
+	}
+
+	248
+	{
+		spritenumber = 31;
+		spritesubnumber = 2;
+	}
+
+	249
+	{
+		spritenumber = 31;
+		spritesubnumber = 3;
+	}
+
+	250
+	{
+		spritenumber = 31;
+		spritesubnumber = 3;
+	}
+
+	251
+	{
+		spritenumber = 31;
+		spritesubnumber = 4;
+	}
+
+	252
+	{
+		spritenumber = 31;
+		spritesubnumber = 4;
+	}
+
+	253
+	{
+		spritenumber = 31;
+		spritesubnumber = 5;
+	}
+
+	254
+	{
+		spritenumber = 31;
+		spritesubnumber = 5;
+	}
+
+	255
+	{
+		spritenumber = 31;
+		spritesubnumber = 6;
+	}
+
+	256
+	{
+		spritenumber = 31;
+		spritesubnumber = 6;
+	}
+
+	257
+	{
+		spritenumber = 31;
+		spritesubnumber = 7;
+	}
+
+	258
+	{
+		spritenumber = 31;
+		spritesubnumber = 8;
+	}
+
+	259
+	{
+		spritenumber = 31;
+		spritesubnumber = 9;
+	}
+
+	260
+	{
+		spritenumber = 31;
+		spritesubnumber = 10;
+	}
+
+	261
+	{
+		spritenumber = 31;
+		spritesubnumber = 11;
+	}
+
+	262
+	{
+		spritenumber = 31;
+		spritesubnumber = 12;
+	}
+
+	263
+	{
+		spritenumber = 31;
+		spritesubnumber = 13;
+	}
+
+	264
+	{
+		spritenumber = 31;
+		spritesubnumber = 14;
+	}
+
+	265
+	{
+		spritenumber = 31;
+		spritesubnumber = 15;
+	}
+
+	266
+	{
+		spritenumber = 31;
+		spritesubnumber = 26;
+	}
+
+	267
+	{
+		spritenumber = 31;
+		spritesubnumber = 27;
+	}
+
+	268
+	{
+		spritenumber = 31;
+		spritesubnumber = 28;
+	}
+
+	269
+	{
+		spritenumber = 31;
+		spritesubnumber = 16;
+	}
+
+	270
+	{
+		spritenumber = 31;
+		spritesubnumber = 16;
+	}
+
+	271
+	{
+		spritenumber = 31;
+		spritesubnumber = 16;
+	}
+
+	272
+	{
+		spritenumber = 31;
+		spritesubnumber = 17;
+	}
+
+	273
+	{
+		spritenumber = 31;
+		spritesubnumber = 18;
+	}
+
+	274
+	{
+		spritenumber = 31;
+		spritesubnumber = 19;
+	}
+
+	275
+	{
+		spritenumber = 31;
+		spritesubnumber = 20;
+	}
+
+	276
+	{
+		spritenumber = 31;
+		spritesubnumber = 21;
+	}
+
+	277
+	{
+		spritenumber = 31;
+		spritesubnumber = 22;
+	}
+
+	278
+	{
+		spritenumber = 31;
+		spritesubnumber = 23;
+	}
+
+	279
+	{
+		spritenumber = 31;
+		spritesubnumber = 24;
+	}
+
+	280
+	{
+		spritenumber = 31;
+		spritesubnumber = 25;
+	}
+
+	281
+	{
+		spritenumber = 32;
+	}
+
+	282
+	{
+		spritenumber = 32;
+		spritesubnumber = 1;
+	}
+
+	283
+	{
+		spritenumber = 32;
+	}
+
+	284
+	{
+		spritenumber = 32;
+		spritesubnumber = 1;
+	}
+
+	285
+	{
+		spritenumber = 32;
+		spritesubnumber = 2;
+	}
+
+	286
+	{
+		spritenumber = 32;
+		spritesubnumber = 1;
+	}
+
+	287
+	{
+		spritenumber = 32;
+		spritesubnumber = 2;
+	}
+
+	288
+	{
+		spritenumber = 32;
+		spritesubnumber = 1;
+	}
+
+	289
+	{
+		spritenumber = 32;
+		spritesubnumber = 2;
+	}
+
+	290
+	{
+		spritenumber = 32;
+		spritesubnumber = 3;
+	}
+
+	291
+	{
+		spritenumber = 32;
+		spritesubnumber = 2;
+	}
+
+	292
+	{
+		spritenumber = 32;
+		spritesubnumber = 3;
+	}
+
+	293
+	{
+		spritenumber = 32;
+		spritesubnumber = 2;
+	}
+
+	294
+	{
+		spritenumber = 32;
+		spritesubnumber = 3;
+	}
+
+	295
+	{
+		spritenumber = 32;
+		spritesubnumber = 4;
+	}
+
+	296
+	{
+		spritenumber = 32;
+		spritesubnumber = 3;
+	}
+
+	297
+	{
+		spritenumber = 32;
+		spritesubnumber = 4;
+	}
+
+	298
+	{
+		spritenumber = 32;
+		spritesubnumber = 3;
+	}
+
+	299
+	{
+		spritenumber = 32;
+		spritesubnumber = 4;
+	}
+
+	300
+	{
+		spritenumber = 32;
+		spritesubnumber = 5;
+	}
+
+	301
+	{
+		spritenumber = 32;
+		spritesubnumber = 4;
+	}
+
+	302
+	{
+		spritenumber = 32;
+		spritesubnumber = 5;
+	}
+
+	303
+	{
+		spritenumber = 32;
+		spritesubnumber = 4;
+	}
+
+	304
+	{
+		spritenumber = 32;
+		spritesubnumber = 5;
+	}
+
+	305
+	{
+		spritenumber = 32;
+		spritesubnumber = 6;
+	}
+
+	306
+	{
+		spritenumber = 32;
+		spritesubnumber = 7;
+	}
+
+	307
+	{
+		spritenumber = 32;
+		spritesubnumber = 6;
+	}
+
+	308
+	{
+		spritenumber = 32;
+		spritesubnumber = 7;
+	}
+
+	309
+	{
+		spritenumber = 32;
+		spritesubnumber = 6;
+	}
+
+	310
+	{
+		spritenumber = 32;
+		spritesubnumber = 7;
+	}
+
+	311
+	{
+		spritenumber = 17;
+		spritesubnumber = 1;
+	}
+
+	312
+	{
+		spritenumber = 17;
+		spritesubnumber = 2;
+	}
+
+	313
+	{
+		spritenumber = 17;
+		spritesubnumber = 1;
+	}
+
+	314
+	{
+		spritenumber = 17;
+		spritesubnumber = 2;
+	}
+
+	315
+	{
+		spritenumber = 17;
+		spritesubnumber = 3;
+	}
+
+	316
+	{
+		spritenumber = 33;
+	}
+
+	317
+	{
+		spritenumber = 33;
+		spritesubnumber = 1;
+	}
+
+	318
+	{
+		spritenumber = 34;
+	}
+
+	319
+	{
+		spritenumber = 34;
+		spritesubnumber = 1;
+	}
+
+	320
+	{
+		spritenumber = 34;
+		spritesubnumber = 2;
+	}
+
+	321
+	{
+		spritenumber = 35;
+	}
+
+	322
+	{
+		spritenumber = 35;
+		spritesubnumber = 1;
+	}
+
+	323
+	{
+		spritenumber = 35;
+	}
+
+	324
+	{
+		spritenumber = 35;
+	}
+
+	325
+	{
+		spritenumber = 35;
+		spritesubnumber = 1;
+	}
+
+	326
+	{
+		spritenumber = 35;
+		spritesubnumber = 1;
+	}
+
+	327
+	{
+		spritenumber = 35;
+		spritesubnumber = 2;
+	}
+
+	328
+	{
+		spritenumber = 35;
+		spritesubnumber = 2;
+	}
+
+	329
+	{
+		spritenumber = 35;
+		spritesubnumber = 3;
+	}
+
+	330
+	{
+		spritenumber = 35;
+		spritesubnumber = 3;
+	}
+
+	331
+	{
+		spritenumber = 35;
+		spritesubnumber = 4;
+	}
+
+	332
+	{
+		spritenumber = 35;
+		spritesubnumber = 4;
+	}
+
+	333
+	{
+		spritenumber = 35;
+		spritesubnumber = 5;
+	}
+
+	334
+	{
+		spritenumber = 35;
+		spritesubnumber = 5;
+	}
+
+	335
+	{
+		spritenumber = 35;
+		spritesubnumber = 6;
+	}
+
+	336
+	{
+		spritenumber = 35;
+		spritesubnumber = 6;
+	}
+
+	337
+	{
+		spritenumber = 35;
+		spritesubnumber = 7;
+	}
+
+	338
+	{
+		spritenumber = 35;
+		spritesubnumber = 8;
+	}
+
+	339
+	{
+		spritenumber = 35;
+		spritesubnumber = 9;
+	}
+
+	340
+	{
+		spritenumber = 35;
+		spritesubnumber = 9;
+	}
+
+	341
+	{
+		spritenumber = 35;
+		spritesubnumber = 10;
+	}
+
+	342
+	{
+		spritenumber = 35;
+		spritesubnumber = 10;
+	}
+
+	343
+	{
+		spritenumber = 35;
+		spritesubnumber = 11;
+	}
+
+	344
+	{
+		spritenumber = 35;
+		spritesubnumber = 11;
+	}
+
+	345
+	{
+		spritenumber = 35;
+		spritesubnumber = 11;
+	}
+
+	346
+	{
+		spritenumber = 35;
+		spritesubnumber = 12;
+	}
+
+	347
+	{
+		spritenumber = 35;
+		spritesubnumber = 13;
+	}
+
+	348
+	{
+		spritenumber = 35;
+		spritesubnumber = 14;
+	}
+
+	349
+	{
+		spritenumber = 35;
+		spritesubnumber = 15;
+	}
+
+	350
+	{
+		spritenumber = 35;
+		spritesubnumber = 16;
+	}
+
+	351
+	{
+		spritenumber = 35;
+		spritesubnumber = 16;
+	}
+
+	352
+	{
+		spritenumber = 35;
+		spritesubnumber = 15;
+	}
+
+	353
+	{
+		spritenumber = 35;
+		spritesubnumber = 14;
+	}
+
+	354
+	{
+		spritenumber = 35;
+		spritesubnumber = 13;
+	}
+
+	355
+	{
+		spritenumber = 35;
+		spritesubnumber = 12;
+	}
+
+	356
+	{
+		spritenumber = 35;
+		spritesubnumber = 11;
+	}
+
+	357
+	{
+		spritenumber = 36;
+	}
+
+	358
+	{
+		spritenumber = 36;
+		spritesubnumber = 1;
+	}
+
+	359
+	{
+		spritenumber = 22;
+		spritesubnumber = 1;
+	}
+
+	360
+	{
+		spritenumber = 22;
+		spritesubnumber = 2;
+	}
+
+	361
+	{
+		spritenumber = 22;
+		spritesubnumber = 3;
+	}
+
+	362
+	{
+		spritenumber = 37;
+	}
+
+	363
+	{
+		spritenumber = 37;
+		spritesubnumber = 1;
+	}
+
+	364
+	{
+		spritenumber = 37;
+	}
+
+	365
+	{
+		spritenumber = 37;
+	}
+
+	366
+	{
+		spritenumber = 37;
+		spritesubnumber = 1;
+	}
+
+	367
+	{
+		spritenumber = 37;
+		spritesubnumber = 1;
+	}
+
+	368
+	{
+		spritenumber = 37;
+		spritesubnumber = 2;
+	}
+
+	369
+	{
+		spritenumber = 37;
+		spritesubnumber = 2;
+	}
+
+	370
+	{
+		spritenumber = 37;
+		spritesubnumber = 3;
+	}
+
+	371
+	{
+		spritenumber = 37;
+		spritesubnumber = 3;
+	}
+
+	372
+	{
+		spritenumber = 37;
+		spritesubnumber = 4;
+	}
+
+	373
+	{
+		spritenumber = 37;
+		spritesubnumber = 4;
+	}
+
+	374
+	{
+		spritenumber = 37;
+		spritesubnumber = 5;
+	}
+
+	375
+	{
+		spritenumber = 37;
+		spritesubnumber = 5;
+	}
+
+	376
+	{
+		spritenumber = 37;
+		spritesubnumber = 6;
+	}
+
+	377
+	{
+		spritenumber = 37;
+		spritesubnumber = 7;
+	}
+
+	378
+	{
+		spritenumber = 37;
+		spritesubnumber = 8;
+	}
+
+	379
+	{
+		spritenumber = 37;
+		spritesubnumber = 6;
+	}
+
+	380
+	{
+		spritenumber = 37;
+		spritesubnumber = 7;
+	}
+
+	381
+	{
+		spritenumber = 37;
+		spritesubnumber = 8;
+	}
+
+	382
+	{
+		spritenumber = 37;
+		spritesubnumber = 6;
+	}
+
+	383
+	{
+		spritenumber = 37;
+		spritesubnumber = 7;
+	}
+
+	384
+	{
+		spritenumber = 37;
+		spritesubnumber = 8;
+	}
+
+	385
+	{
+		spritenumber = 37;
+		spritesubnumber = 6;
+	}
+
+	386
+	{
+		spritenumber = 37;
+		spritesubnumber = 9;
+	}
+
+	387
+	{
+		spritenumber = 37;
+		spritesubnumber = 9;
+	}
+
+	388
+	{
+		spritenumber = 37;
+		spritesubnumber = 10;
+	}
+
+	389
+	{
+		spritenumber = 37;
+		spritesubnumber = 11;
+	}
+
+	390
+	{
+		spritenumber = 37;
+		spritesubnumber = 12;
+	}
+
+	391
+	{
+		spritenumber = 37;
+		spritesubnumber = 13;
+	}
+
+	392
+	{
+		spritenumber = 37;
+		spritesubnumber = 14;
+	}
+
+	393
+	{
+		spritenumber = 37;
+		spritesubnumber = 15;
+	}
+
+	394
+	{
+		spritenumber = 37;
+		spritesubnumber = 16;
+	}
+
+	395
+	{
+		spritenumber = 37;
+		spritesubnumber = 17;
+	}
+
+	396
+	{
+		spritenumber = 37;
+		spritesubnumber = 18;
+	}
+
+	397
+	{
+		spritenumber = 37;
+		spritesubnumber = 19;
+	}
+
+	398
+	{
+		spritenumber = 37;
+		spritesubnumber = 17;
+	}
+
+	399
+	{
+		spritenumber = 37;
+		spritesubnumber = 16;
+	}
+
+	400
+	{
+		spritenumber = 37;
+		spritesubnumber = 15;
+	}
+
+	401
+	{
+		spritenumber = 37;
+		spritesubnumber = 14;
+	}
+
+	402
+	{
+		spritenumber = 37;
+		spritesubnumber = 13;
+	}
+
+	403
+	{
+		spritenumber = 37;
+		spritesubnumber = 12;
+	}
+
+	404
+	{
+		spritenumber = 37;
+		spritesubnumber = 11;
+	}
+
+	405
+	{
+		spritenumber = 37;
+		spritesubnumber = 10;
+	}
+
+	406
+	{
+		spritenumber = 38;
+	}
+
+	407
+	{
+		spritenumber = 38;
+		spritesubnumber = 1;
+	}
+
+	408
+	{
+		spritenumber = 38;
+	}
+
+	409
+	{
+		spritenumber = 38;
+	}
+
+	410
+	{
+		spritenumber = 38;
+		spritesubnumber = 1;
+	}
+
+	411
+	{
+		spritenumber = 38;
+		spritesubnumber = 1;
+	}
+
+	412
+	{
+		spritenumber = 38;
+		spritesubnumber = 2;
+	}
+
+	413
+	{
+		spritenumber = 38;
+		spritesubnumber = 2;
+	}
+
+	414
+	{
+		spritenumber = 38;
+		spritesubnumber = 3;
+	}
+
+	415
+	{
+		spritenumber = 38;
+		spritesubnumber = 3;
+	}
+
+	416
+	{
+		spritenumber = 38;
+		spritesubnumber = 4;
+	}
+
+	417
+	{
+		spritenumber = 38;
+		spritesubnumber = 5;
+	}
+
+	418
+	{
+		spritenumber = 38;
+		spritesubnumber = 4;
+	}
+
+	419
+	{
+		spritenumber = 38;
+		spritesubnumber = 5;
+	}
+
+	420
+	{
+		spritenumber = 38;
+		spritesubnumber = 6;
+	}
+
+	421
+	{
+		spritenumber = 38;
+		spritesubnumber = 6;
+	}
+
+	422
+	{
+		spritenumber = 38;
+		spritesubnumber = 7;
+	}
+
+	423
+	{
+		spritenumber = 38;
+		spritesubnumber = 8;
+	}
+
+	424
+	{
+		spritenumber = 38;
+		spritesubnumber = 9;
+	}
+
+	425
+	{
+		spritenumber = 38;
+		spritesubnumber = 10;
+	}
+
+	426
+	{
+		spritenumber = 38;
+		spritesubnumber = 11;
+	}
+
+	427
+	{
+		spritenumber = 38;
+		spritesubnumber = 12;
+	}
+
+	428
+	{
+		spritenumber = 38;
+		spritesubnumber = 13;
+	}
+
+	429
+	{
+		spritenumber = 38;
+		spritesubnumber = 14;
+	}
+
+	430
+	{
+		spritenumber = 38;
+		spritesubnumber = 15;
+	}
+
+	431
+	{
+		spritenumber = 38;
+		spritesubnumber = 16;
+	}
+
+	432
+	{
+		spritenumber = 38;
+		spritesubnumber = 17;
+	}
+
+	433
+	{
+		spritenumber = 38;
+		spritesubnumber = 18;
+	}
+
+	434
+	{
+		spritenumber = 38;
+		spritesubnumber = 19;
+	}
+
+	435
+	{
+		spritenumber = 38;
+		spritesubnumber = 13;
+	}
+
+	436
+	{
+		spritenumber = 38;
+		spritesubnumber = 12;
+	}
+
+	437
+	{
+		spritenumber = 38;
+		spritesubnumber = 11;
+	}
+
+	438
+	{
+		spritenumber = 38;
+		spritesubnumber = 10;
+	}
+
+	439
+	{
+		spritenumber = 38;
+		spritesubnumber = 9;
+	}
+
+	440
+	{
+		spritenumber = 38;
+		spritesubnumber = 8;
+	}
+
+	441
+	{
+		spritenumber = 38;
+		spritesubnumber = 7;
+	}
+
+	442
+	{
+		spritenumber = 0;
+	}
+
+	443
+	{
+		spritenumber = 0;
+		spritesubnumber = 1;
+	}
+
+	444
+	{
+		spritenumber = 0;
+	}
+
+	445
+	{
+		spritenumber = 0;
+	}
+
+	446
+	{
+		spritenumber = 0;
+		spritesubnumber = 1;
+	}
+
+	447
+	{
+		spritenumber = 0;
+		spritesubnumber = 1;
+	}
+
+	448
+	{
+		spritenumber = 0;
+		spritesubnumber = 2;
+	}
+
+	449
+	{
+		spritenumber = 0;
+		spritesubnumber = 2;
+	}
+
+	450
+	{
+		spritenumber = 0;
+		spritesubnumber = 3;
+	}
+
+	451
+	{
+		spritenumber = 0;
+		spritesubnumber = 3;
+	}
+
+	452
+	{
+		spritenumber = 0;
+		spritesubnumber = 4;
+	}
+
+	453
+	{
+		spritenumber = 0;
+		spritesubnumber = 5;
+	}
+
+	454
+	{
+		spritenumber = 0;
+		spritesubnumber = 6;
+	}
+
+	455
+	{
+		spritenumber = 0;
+		spritesubnumber = 7;
+	}
+
+	456
+	{
+		spritenumber = 0;
+		spritesubnumber = 7;
+	}
+
+	457
+	{
+		spritenumber = 0;
+		spritesubnumber = 8;
+	}
+
+	458
+	{
+		spritenumber = 0;
+		spritesubnumber = 9;
+	}
+
+	459
+	{
+		spritenumber = 0;
+		spritesubnumber = 10;
+	}
+
+	460
+	{
+		spritenumber = 0;
+		spritesubnumber = 11;
+	}
+
+	461
+	{
+		spritenumber = 0;
+		spritesubnumber = 12;
+	}
+
+	462
+	{
+		spritenumber = 0;
+		spritesubnumber = 13;
+	}
+
+	463
+	{
+		spritenumber = 0;
+		spritesubnumber = 14;
+	}
+
+	464
+	{
+		spritenumber = 0;
+		spritesubnumber = 15;
+	}
+
+	465
+	{
+		spritenumber = 0;
+		spritesubnumber = 16;
+	}
+
+	466
+	{
+		spritenumber = 0;
+		spritesubnumber = 17;
+	}
+
+	467
+	{
+		spritenumber = 0;
+		spritesubnumber = 18;
+	}
+
+	468
+	{
+		spritenumber = 0;
+		spritesubnumber = 19;
+	}
+
+	469
+	{
+		spritenumber = 0;
+		spritesubnumber = 20;
+	}
+
+	470
+	{
+		spritenumber = 0;
+		spritesubnumber = 12;
+	}
+
+	471
+	{
+		spritenumber = 0;
+		spritesubnumber = 11;
+	}
+
+	472
+	{
+		spritenumber = 0;
+		spritesubnumber = 10;
+	}
+
+	473
+	{
+		spritenumber = 0;
+		spritesubnumber = 9;
+	}
+
+	474
+	{
+		spritenumber = 0;
+		spritesubnumber = 8;
+	}
+
+	475
+	{
+		spritenumber = 39;
+	}
+
+	476
+	{
+		spritenumber = 39;
+		spritesubnumber = 1;
+	}
+
+	477
+	{
+		spritenumber = 39;
+	}
+
+	478
+	{
+		spritenumber = 39;
+	}
+
+	479
+	{
+		spritenumber = 39;
+		spritesubnumber = 1;
+	}
+
+	480
+	{
+		spritenumber = 39;
+		spritesubnumber = 1;
+	}
+
+	481
+	{
+		spritenumber = 39;
+		spritesubnumber = 2;
+	}
+
+	482
+	{
+		spritenumber = 39;
+		spritesubnumber = 2;
+	}
+
+	483
+	{
+		spritenumber = 39;
+		spritesubnumber = 3;
+	}
+
+	484
+	{
+		spritenumber = 39;
+		spritesubnumber = 3;
+	}
+
+	485
+	{
+		spritenumber = 39;
+		spritesubnumber = 4;
+	}
+
+	486
+	{
+		spritenumber = 39;
+		spritesubnumber = 5;
+	}
+
+	487
+	{
+		spritenumber = 39;
+		spritesubnumber = 6;
+	}
+
+	488
+	{
+		spritenumber = 39;
+		spritesubnumber = 7;
+	}
+
+	489
+	{
+		spritenumber = 39;
+		spritesubnumber = 7;
+	}
+
+	490
+	{
+		spritenumber = 39;
+		spritesubnumber = 8;
+	}
+
+	491
+	{
+		spritenumber = 39;
+		spritesubnumber = 9;
+	}
+
+	492
+	{
+		spritenumber = 39;
+		spritesubnumber = 10;
+	}
+
+	493
+	{
+		spritenumber = 39;
+		spritesubnumber = 11;
+	}
+
+	494
+	{
+		spritenumber = 39;
+		spritesubnumber = 12;
+	}
+
+	495
+	{
+		spritenumber = 39;
+		spritesubnumber = 13;
+	}
+
+	496
+	{
+		spritenumber = 39;
+		spritesubnumber = 13;
+	}
+
+	497
+	{
+		spritenumber = 39;
+		spritesubnumber = 12;
+	}
+
+	498
+	{
+		spritenumber = 39;
+		spritesubnumber = 11;
+	}
+
+	499
+	{
+		spritenumber = 39;
+		spritesubnumber = 10;
+	}
+
+	500
+	{
+		spritenumber = 39;
+		spritesubnumber = 9;
+	}
+
+	501
+	{
+		spritenumber = 39;
+		spritesubnumber = 8;
+	}
+
+	502
+	{
+		spritenumber = 40;
+	}
+
+	503
+	{
+		spritenumber = 40;
+	}
+
+	504
+	{
+		spritenumber = 40;
+		spritesubnumber = 1;
+	}
+
+	505
+	{
+		spritenumber = 40;
+		spritesubnumber = 2;
+	}
+
+	506
+	{
+		spritenumber = 40;
+		spritesubnumber = 3;
+	}
+
+	507
+	{
+		spritenumber = 40;
+		spritesubnumber = 4;
+	}
+
+	508
+	{
+		spritenumber = 40;
+		spritesubnumber = 4;
+	}
+
+	509
+	{
+		spritenumber = 40;
+		spritesubnumber = 5;
+	}
+
+	510
+	{
+		spritenumber = 40;
+		spritesubnumber = 6;
+	}
+
+	511
+	{
+		spritenumber = 40;
+		spritesubnumber = 7;
+	}
+
+	512
+	{
+		spritenumber = 40;
+		spritesubnumber = 8;
+	}
+
+	513
+	{
+		spritenumber = 40;
+		spritesubnumber = 9;
+	}
+
+	514
+	{
+		spritenumber = 40;
+		spritesubnumber = 10;
+	}
+
+	515
+	{
+		spritenumber = 40;
+		spritesubnumber = 11;
+	}
+
+	516
+	{
+		spritenumber = 40;
+		spritesubnumber = 11;
+	}
+
+	517
+	{
+		spritenumber = 40;
+		spritesubnumber = 10;
+	}
+
+	518
+	{
+		spritenumber = 40;
+		spritesubnumber = 9;
+	}
+
+	519
+	{
+		spritenumber = 40;
+		spritesubnumber = 8;
+	}
+
+	520
+	{
+		spritenumber = 40;
+		spritesubnumber = 7;
+	}
+
+	521
+	{
+		spritenumber = 40;
+		spritesubnumber = 6;
+	}
+
+	522
+	{
+		spritenumber = 41;
+	}
+
+	523
+	{
+		spritenumber = 41;
+		spritesubnumber = 1;
+	}
+
+	524
+	{
+		spritenumber = 41;
+		spritesubnumber = 2;
+	}
+
+	525
+	{
+		spritenumber = 41;
+		spritesubnumber = 3;
+	}
+
+	526
+	{
+		spritenumber = 41;
+		spritesubnumber = 4;
+	}
+
+	527
+	{
+		spritenumber = 42;
+	}
+
+	528
+	{
+		spritenumber = 42;
+		spritesubnumber = 1;
+	}
+
+	529
+	{
+		spritenumber = 42;
+	}
+
+	530
+	{
+		spritenumber = 42;
+	}
+
+	531
+	{
+		spritenumber = 42;
+		spritesubnumber = 1;
+	}
+
+	532
+	{
+		spritenumber = 42;
+		spritesubnumber = 1;
+	}
+
+	533
+	{
+		spritenumber = 42;
+		spritesubnumber = 2;
+	}
+
+	534
+	{
+		spritenumber = 42;
+		spritesubnumber = 2;
+	}
+
+	535
+	{
+		spritenumber = 42;
+		spritesubnumber = 3;
+	}
+
+	536
+	{
+		spritenumber = 42;
+		spritesubnumber = 3;
+	}
+
+	537
+	{
+		spritenumber = 42;
+		spritesubnumber = 4;
+	}
+
+	538
+	{
+		spritenumber = 42;
+		spritesubnumber = 5;
+	}
+
+	539
+	{
+		spritenumber = 42;
+		spritesubnumber = 6;
+	}
+
+	540
+	{
+		spritenumber = 42;
+		spritesubnumber = 7;
+	}
+
+	541
+	{
+		spritenumber = 42;
+		spritesubnumber = 7;
+	}
+
+	542
+	{
+		spritenumber = 42;
+		spritesubnumber = 8;
+	}
+
+	543
+	{
+		spritenumber = 42;
+		spritesubnumber = 9;
+	}
+
+	544
+	{
+		spritenumber = 42;
+		spritesubnumber = 10;
+	}
+
+	545
+	{
+		spritenumber = 42;
+		spritesubnumber = 11;
+	}
+
+	546
+	{
+		spritenumber = 42;
+		spritesubnumber = 12;
+	}
+
+	547
+	{
+		spritenumber = 42;
+		spritesubnumber = 13;
+	}
+
+	548
+	{
+		spritenumber = 42;
+		spritesubnumber = 14;
+	}
+
+	549
+	{
+		spritenumber = 42;
+		spritesubnumber = 14;
+	}
+
+	550
+	{
+		spritenumber = 42;
+		spritesubnumber = 13;
+	}
+
+	551
+	{
+		spritenumber = 42;
+		spritesubnumber = 12;
+	}
+
+	552
+	{
+		spritenumber = 42;
+		spritesubnumber = 11;
+	}
+
+	553
+	{
+		spritenumber = 42;
+		spritesubnumber = 10;
+	}
+
+	554
+	{
+		spritenumber = 42;
+		spritesubnumber = 9;
+	}
+
+	555
+	{
+		spritenumber = 42;
+		spritesubnumber = 8;
+	}
+
+	556
+	{
+		spritenumber = 43;
+	}
+
+	557
+	{
+		spritenumber = 43;
+		spritesubnumber = 1;
+	}
+
+	558
+	{
+		spritenumber = 43;
+	}
+
+	559
+	{
+		spritenumber = 43;
+	}
+
+	560
+	{
+		spritenumber = 43;
+		spritesubnumber = 1;
+	}
+
+	561
+	{
+		spritenumber = 43;
+		spritesubnumber = 1;
+	}
+
+	562
+	{
+		spritenumber = 43;
+		spritesubnumber = 2;
+	}
+
+	563
+	{
+		spritenumber = 43;
+		spritesubnumber = 2;
+	}
+
+	564
+	{
+		spritenumber = 43;
+		spritesubnumber = 3;
+	}
+
+	565
+	{
+		spritenumber = 43;
+		spritesubnumber = 3;
+	}
+
+	566
+	{
+		spritenumber = 43;
+		spritesubnumber = 4;
+	}
+
+	567
+	{
+		spritenumber = 43;
+		spritesubnumber = 5;
+	}
+
+	568
+	{
+		spritenumber = 43;
+		spritesubnumber = 6;
+	}
+
+	569
+	{
+		spritenumber = 43;
+		spritesubnumber = 7;
+	}
+
+	570
+	{
+		spritenumber = 43;
+		spritesubnumber = 7;
+	}
+
+	571
+	{
+		spritenumber = 43;
+		spritesubnumber = 8;
+	}
+
+	572
+	{
+		spritenumber = 43;
+		spritesubnumber = 9;
+	}
+
+	573
+	{
+		spritenumber = 43;
+		spritesubnumber = 10;
+	}
+
+	574
+	{
+		spritenumber = 43;
+		spritesubnumber = 11;
+	}
+
+	575
+	{
+		spritenumber = 43;
+		spritesubnumber = 12;
+	}
+
+	576
+	{
+		spritenumber = 43;
+		spritesubnumber = 13;
+	}
+
+	577
+	{
+		spritenumber = 43;
+		spritesubnumber = 14;
+	}
+
+	578
+	{
+		spritenumber = 43;
+		spritesubnumber = 14;
+	}
+
+	579
+	{
+		spritenumber = 43;
+		spritesubnumber = 13;
+	}
+
+	580
+	{
+		spritenumber = 43;
+		spritesubnumber = 12;
+	}
+
+	581
+	{
+		spritenumber = 43;
+		spritesubnumber = 11;
+	}
+
+	582
+	{
+		spritenumber = 43;
+		spritesubnumber = 10;
+	}
+
+	583
+	{
+		spritenumber = 43;
+		spritesubnumber = 9;
+	}
+
+	584
+	{
+		spritenumber = 43;
+		spritesubnumber = 8;
+	}
+
+	585
+	{
+		spritenumber = 44;
+	}
+
+	586
+	{
+		spritenumber = 44;
+		spritesubnumber = 1;
+	}
+
+	587
+	{
+		spritenumber = 44;
+	}
+
+	588
+	{
+		spritenumber = 44;
+		spritesubnumber = 1;
+	}
+
+	589
+	{
+		spritenumber = 44;
+		spritesubnumber = 2;
+	}
+
+	590
+	{
+		spritenumber = 44;
+		spritesubnumber = 3;
+	}
+
+	591
+	{
+		spritenumber = 44;
+		spritesubnumber = 2;
+	}
+
+	592
+	{
+		spritenumber = 44;
+		spritesubnumber = 3;
+	}
+
+	593
+	{
+		spritenumber = 44;
+		spritesubnumber = 4;
+	}
+
+	594
+	{
+		spritenumber = 44;
+		spritesubnumber = 4;
+	}
+
+	595
+	{
+		spritenumber = 44;
+		spritesubnumber = 5;
+	}
+
+	596
+	{
+		spritenumber = 44;
+		spritesubnumber = 6;
+	}
+
+	597
+	{
+		spritenumber = 44;
+		spritesubnumber = 7;
+	}
+
+	598
+	{
+		spritenumber = 44;
+		spritesubnumber = 8;
+	}
+
+	599
+	{
+		spritenumber = 44;
+		spritesubnumber = 9;
+	}
+
+	600
+	{
+		spritenumber = 44;
+		spritesubnumber = 10;
+	}
+
+	601
+	{
+		spritenumber = 45;
+	}
+
+	602
+	{
+		spritenumber = 45;
+		spritesubnumber = 1;
+	}
+
+	603
+	{
+		spritenumber = 45;
+	}
+
+	604
+	{
+		spritenumber = 45;
+	}
+
+	605
+	{
+		spritenumber = 45;
+		spritesubnumber = 1;
+	}
+
+	606
+	{
+		spritenumber = 45;
+		spritesubnumber = 1;
+	}
+
+	607
+	{
+		spritenumber = 45;
+		spritesubnumber = 2;
+	}
+
+	608
+	{
+		spritenumber = 45;
+		spritesubnumber = 2;
+	}
+
+	609
+	{
+		spritenumber = 45;
+		spritesubnumber = 3;
+	}
+
+	610
+	{
+		spritenumber = 45;
+		spritesubnumber = 3;
+	}
+
+	611
+	{
+		spritenumber = 45;
+		spritesubnumber = 4;
+	}
+
+	612
+	{
+		spritenumber = 45;
+		spritesubnumber = 4;
+	}
+
+	613
+	{
+		spritenumber = 45;
+		spritesubnumber = 5;
+	}
+
+	614
+	{
+		spritenumber = 45;
+		spritesubnumber = 5;
+	}
+
+	615
+	{
+		spritenumber = 45;
+	}
+
+	616
+	{
+		spritenumber = 45;
+		spritesubnumber = 6;
+	}
+
+	617
+	{
+		spritenumber = 45;
+		spritesubnumber = 7;
+	}
+
+	618
+	{
+		spritenumber = 45;
+		spritesubnumber = 7;
+	}
+
+	619
+	{
+		spritenumber = 45;
+		spritesubnumber = 8;
+	}
+
+	620
+	{
+		spritenumber = 45;
+		spritesubnumber = 8;
+	}
+
+	621
+	{
+		spritenumber = 45;
+		spritesubnumber = 9;
+	}
+
+	622
+	{
+		spritenumber = 45;
+		spritesubnumber = 10;
+	}
+
+	623
+	{
+		spritenumber = 45;
+		spritesubnumber = 11;
+	}
+
+	624
+	{
+		spritenumber = 45;
+		spritesubnumber = 12;
+	}
+
+	625
+	{
+		spritenumber = 45;
+		spritesubnumber = 13;
+	}
+
+	626
+	{
+		spritenumber = 45;
+		spritesubnumber = 14;
+	}
+
+	627
+	{
+		spritenumber = 45;
+		spritesubnumber = 15;
+	}
+
+	628
+	{
+		spritenumber = 45;
+		spritesubnumber = 16;
+	}
+
+	629
+	{
+		spritenumber = 45;
+		spritesubnumber = 17;
+	}
+
+	630
+	{
+		spritenumber = 45;
+		spritesubnumber = 18;
+	}
+
+	631
+	{
+		spritenumber = 45;
+		spritesubnumber = 18;
+	}
+
+	632
+	{
+		spritenumber = 46;
+	}
+
+	633
+	{
+		spritenumber = 46;
+		spritesubnumber = 1;
+	}
+
+	634
+	{
+		spritenumber = 46;
+	}
+
+	635
+	{
+		spritenumber = 46;
+	}
+
+	636
+	{
+		spritenumber = 46;
+	}
+
+	637
+	{
+		spritenumber = 46;
+		spritesubnumber = 1;
+	}
+
+	638
+	{
+		spritenumber = 46;
+		spritesubnumber = 1;
+	}
+
+	639
+	{
+		spritenumber = 46;
+		spritesubnumber = 2;
+	}
+
+	640
+	{
+		spritenumber = 46;
+		spritesubnumber = 2;
+	}
+
+	641
+	{
+		spritenumber = 46;
+		spritesubnumber = 3;
+	}
+
+	642
+	{
+		spritenumber = 46;
+		spritesubnumber = 3;
+	}
+
+	643
+	{
+		spritenumber = 46;
+		spritesubnumber = 4;
+	}
+
+	644
+	{
+		spritenumber = 46;
+		spritesubnumber = 4;
+	}
+
+	645
+	{
+		spritenumber = 46;
+		spritesubnumber = 5;
+	}
+
+	646
+	{
+		spritenumber = 46;
+		spritesubnumber = 5;
+	}
+
+	647
+	{
+		spritenumber = 46;
+	}
+
+	648
+	{
+		spritenumber = 46;
+		spritesubnumber = 6;
+	}
+
+	649
+	{
+		spritenumber = 46;
+		spritesubnumber = 7;
+	}
+
+	650
+	{
+		spritenumber = 46;
+		spritesubnumber = 7;
+	}
+
+	651
+	{
+		spritenumber = 46;
+		spritesubnumber = 8;
+	}
+
+	652
+	{
+		spritenumber = 46;
+		spritesubnumber = 8;
+	}
+
+	653
+	{
+		spritenumber = 46;
+		spritesubnumber = 9;
+	}
+
+	654
+	{
+		spritenumber = 46;
+		spritesubnumber = 10;
+	}
+
+	655
+	{
+		spritenumber = 46;
+		spritesubnumber = 11;
+	}
+
+	656
+	{
+		spritenumber = 46;
+		spritesubnumber = 12;
+	}
+
+	657
+	{
+		spritenumber = 46;
+		spritesubnumber = 13;
+	}
+
+	658
+	{
+		spritenumber = 46;
+		spritesubnumber = 14;
+	}
+
+	659
+	{
+		spritenumber = 46;
+		spritesubnumber = 15;
+	}
+
+	660
+	{
+		spritenumber = 46;
+		spritesubnumber = 15;
+	}
+
+	661
+	{
+		spritenumber = 46;
+		spritesubnumber = 14;
+	}
+
+	662
+	{
+		spritenumber = 46;
+		spritesubnumber = 13;
+	}
+
+	663
+	{
+		spritenumber = 46;
+		spritesubnumber = 12;
+	}
+
+	664
+	{
+		spritenumber = 46;
+		spritesubnumber = 11;
+	}
+
+	665
+	{
+		spritenumber = 46;
+		spritesubnumber = 10;
+	}
+
+	666
+	{
+		spritenumber = 46;
+		spritesubnumber = 9;
+	}
+
+	667
+	{
+		spritenumber = 47;
+	}
+
+	668
+	{
+		spritenumber = 47;
+		spritesubnumber = 1;
+	}
+
+	669
+	{
+		spritenumber = 48;
+	}
+
+	670
+	{
+		spritenumber = 48;
+		spritesubnumber = 1;
+	}
+
+	671
+	{
+		spritenumber = 48;
+		spritesubnumber = 2;
+	}
+
+	672
+	{
+		spritenumber = 48;
+		spritesubnumber = 3;
+	}
+
+	673
+	{
+		spritenumber = 48;
+		spritesubnumber = 4;
+	}
+
+	674
+	{
+		spritenumber = 49;
+	}
+
+	675
+	{
+		spritenumber = 49;
+		spritesubnumber = 1;
+	}
+
+	676
+	{
+		spritenumber = 49;
+	}
+
+	677
+	{
+		spritenumber = 49;
+	}
+
+	678
+	{
+		spritenumber = 49;
+		spritesubnumber = 1;
+	}
+
+	679
+	{
+		spritenumber = 49;
+		spritesubnumber = 1;
+	}
+
+	680
+	{
+		spritenumber = 49;
+		spritesubnumber = 2;
+	}
+
+	681
+	{
+		spritenumber = 49;
+		spritesubnumber = 2;
+	}
+
+	682
+	{
+		spritenumber = 49;
+		spritesubnumber = 3;
+	}
+
+	683
+	{
+		spritenumber = 49;
+		spritesubnumber = 3;
+	}
+
+	684
+	{
+		spritenumber = 49;
+		spritesubnumber = 4;
+	}
+
+	685
+	{
+		spritenumber = 49;
+		spritesubnumber = 5;
+	}
+
+	686
+	{
+		spritenumber = 49;
+		spritesubnumber = 4;
+	}
+
+	687
+	{
+		spritenumber = 49;
+		spritesubnumber = 5;
+	}
+
+	688
+	{
+		spritenumber = 49;
+		spritesubnumber = 4;
+	}
+
+	689
+	{
+		spritenumber = 49;
+		spritesubnumber = 5;
+	}
+
+	690
+	{
+		spritenumber = 49;
+		spritesubnumber = 6;
+	}
+
+	691
+	{
+		spritenumber = 49;
+		spritesubnumber = 7;
+	}
+
+	692
+	{
+		spritenumber = 49;
+		spritesubnumber = 8;
+	}
+
+	693
+	{
+		spritenumber = 49;
+		spritesubnumber = 9;
+	}
+
+	694
+	{
+		spritenumber = 49;
+		spritesubnumber = 10;
+	}
+
+	695
+	{
+		spritenumber = 49;
+		spritesubnumber = 11;
+	}
+
+	696
+	{
+		spritenumber = 49;
+		spritesubnumber = 12;
+	}
+
+	697
+	{
+		spritenumber = 49;
+		spritesubnumber = 13;
+	}
+
+	698
+	{
+		spritenumber = 49;
+		spritesubnumber = 14;
+	}
+
+	699
+	{
+		spritenumber = 49;
+		spritesubnumber = 15;
+	}
+
+	700
+	{
+		spritenumber = 49;
+		spritesubnumber = 15;
+	}
+
+	701
+	{
+		spritenumber = 50;
+	}
+
+	702
+	{
+		spritenumber = 50;
+	}
+
+	703
+	{
+		spritenumber = 50;
+	}
+
+	704
+	{
+		spritenumber = 50;
+		spritesubnumber = 1;
+	}
+
+	705
+	{
+		spritenumber = 50;
+		spritesubnumber = 1;
+	}
+
+	706
+	{
+		spritenumber = 50;
+		spritesubnumber = 2;
+	}
+
+	707
+	{
+		spritenumber = 50;
+		spritesubnumber = 2;
+	}
+
+	708
+	{
+		spritenumber = 50;
+		spritesubnumber = 3;
+	}
+
+	709
+	{
+		spritenumber = 50;
+		spritesubnumber = 4;
+	}
+
+	710
+	{
+		spritenumber = 50;
+		spritesubnumber = 5;
+	}
+
+	711
+	{
+		spritenumber = 50;
+		spritesubnumber = 5;
+	}
+
+	712
+	{
+		spritenumber = 50;
+		spritesubnumber = 6;
+	}
+
+	713
+	{
+		spritenumber = 50;
+		spritesubnumber = 6;
+	}
+
+	714
+	{
+		spritenumber = 50;
+		spritesubnumber = 7;
+	}
+
+	715
+	{
+		spritenumber = 50;
+		spritesubnumber = 8;
+	}
+
+	716
+	{
+		spritenumber = 50;
+		spritesubnumber = 9;
+	}
+
+	717
+	{
+		spritenumber = 50;
+		spritesubnumber = 10;
+	}
+
+	718
+	{
+		spritenumber = 50;
+		spritesubnumber = 11;
+	}
+
+	719
+	{
+		spritenumber = 50;
+		spritesubnumber = 12;
+	}
+
+	720
+	{
+		spritenumber = 50;
+		spritesubnumber = 12;
+	}
+
+	721
+	{
+		spritenumber = 50;
+		spritesubnumber = 11;
+	}
+
+	722
+	{
+		spritenumber = 50;
+		spritesubnumber = 10;
+	}
+
+	723
+	{
+		spritenumber = 50;
+		spritesubnumber = 9;
+	}
+
+	724
+	{
+		spritenumber = 50;
+		spritesubnumber = 8;
+	}
+
+	725
+	{
+		spritenumber = 50;
+		spritesubnumber = 7;
+	}
+
+	726
+	{
+		spritenumber = 51;
+	}
+
+	727
+	{
+		spritenumber = 51;
+		spritesubnumber = 1;
+	}
+
+	728
+	{
+		spritenumber = 51;
+	}
+
+	729
+	{
+		spritenumber = 51;
+	}
+
+	730
+	{
+		spritenumber = 51;
+		spritesubnumber = 1;
+	}
+
+	731
+	{
+		spritenumber = 51;
+		spritesubnumber = 1;
+	}
+
+	732
+	{
+		spritenumber = 51;
+		spritesubnumber = 2;
+	}
+
+	733
+	{
+		spritenumber = 51;
+		spritesubnumber = 2;
+	}
+
+	734
+	{
+		spritenumber = 51;
+		spritesubnumber = 3;
+	}
+
+	735
+	{
+		spritenumber = 51;
+		spritesubnumber = 3;
+	}
+
+	736
+	{
+		spritenumber = 51;
+		spritesubnumber = 4;
+	}
+
+	737
+	{
+		spritenumber = 51;
+		spritesubnumber = 5;
+	}
+
+	738
+	{
+		spritenumber = 51;
+		spritesubnumber = 6;
+	}
+
+	739
+	{
+		spritenumber = 51;
+		spritesubnumber = 5;
+	}
+
+	740
+	{
+		spritenumber = 51;
+		spritesubnumber = 6;
+	}
+
+	741
+	{
+		spritenumber = 51;
+		spritesubnumber = 5;
+	}
+
+	742
+	{
+		spritenumber = 51;
+		spritesubnumber = 7;
+	}
+
+	743
+	{
+		spritenumber = 51;
+		spritesubnumber = 7;
+	}
+
+	744
+	{
+		spritenumber = 51;
+		spritesubnumber = 8;
+	}
+
+	745
+	{
+		spritenumber = 51;
+		spritesubnumber = 9;
+	}
+
+	746
+	{
+		spritenumber = 51;
+		spritesubnumber = 10;
+	}
+
+	747
+	{
+		spritenumber = 51;
+		spritesubnumber = 11;
+	}
+
+	748
+	{
+		spritenumber = 51;
+		spritesubnumber = 12;
+	}
+
+	749
+	{
+		spritenumber = 51;
+		spritesubnumber = 13;
+	}
+
+	750
+	{
+		spritenumber = 51;
+		spritesubnumber = 14;
+	}
+
+	751
+	{
+		spritenumber = 51;
+		spritesubnumber = 15;
+	}
+
+	752
+	{
+		spritenumber = 51;
+		spritesubnumber = 16;
+	}
+
+	753
+	{
+		spritenumber = 51;
+		spritesubnumber = 17;
+	}
+
+	754
+	{
+		spritenumber = 51;
+		spritesubnumber = 18;
+	}
+
+	755
+	{
+		spritenumber = 51;
+		spritesubnumber = 19;
+	}
+
+	756
+	{
+		spritenumber = 51;
+		spritesubnumber = 20;
+	}
+
+	757
+	{
+		spritenumber = 51;
+		spritesubnumber = 21;
+	}
+
+	758
+	{
+		spritenumber = 51;
+		spritesubnumber = 12;
+	}
+
+	759
+	{
+		spritenumber = 51;
+		spritesubnumber = 11;
+	}
+
+	760
+	{
+		spritenumber = 51;
+		spritesubnumber = 10;
+	}
+
+	761
+	{
+		spritenumber = 51;
+		spritesubnumber = 9;
+	}
+
+	762
+	{
+		spritenumber = 51;
+		spritesubnumber = 8;
+	}
+
+	763
+	{
+		spritenumber = 52;
+	}
+
+	764
+	{
+		spritenumber = 52;
+	}
+
+	765
+	{
+		spritenumber = 52;
+		spritesubnumber = 1;
+	}
+
+	766
+	{
+		spritenumber = 52;
+		spritesubnumber = 2;
+	}
+
+	767
+	{
+		spritenumber = 52;
+		spritesubnumber = 3;
+	}
+
+	768
+	{
+		spritenumber = 52;
+		spritesubnumber = 4;
+	}
+
+	769
+	{
+		spritenumber = 52;
+		spritesubnumber = 5;
+	}
+
+	770
+	{
+		spritenumber = 52;
+		spritesubnumber = 6;
+	}
+
+	771
+	{
+		spritenumber = 52;
+		spritesubnumber = 7;
+	}
+
+	772
+	{
+		spritenumber = 52;
+		spritesubnumber = 8;
+	}
+
+	773
+	{
+		spritenumber = 52;
+		spritesubnumber = 9;
+	}
+
+	774
+	{
+		spritenumber = 52;
+		spritesubnumber = 10;
+	}
+
+	775
+	{
+		spritenumber = 52;
+		spritesubnumber = 11;
+	}
+
+	776
+	{
+		spritenumber = 52;
+		spritesubnumber = 12;
+	}
+
+	777
+	{
+		spritenumber = 52;
+		spritesubnumber = 12;
+	}
+
+	778
+	{
+		spritenumber = 53;
+	}
+
+	779
+	{
+		spritenumber = 53;
+		spritesubnumber = 1;
+	}
+
+	780
+	{
+		spritenumber = 53;
+	}
+
+	781
+	{
+		spritenumber = 53;
+	}
+
+	782
+	{
+		spritenumber = 53;
+	}
+
+	783
+	{
+		spritenumber = 53;
+	}
+
+	784
+	{
+		spritenumber = 51;
+	}
+
+	785
+	{
+		spritenumber = 51;
+	}
+
+	786
+	{
+		spritenumber = 51;
+	}
+
+	787
+	{
+		spritenumber = 54;
+	}
+
+	788
+	{
+		spritenumber = 54;
+		spritesubnumber = 1;
+	}
+
+	789
+	{
+		spritenumber = 54;
+		spritesubnumber = 2;
+	}
+
+	790
+	{
+		spritenumber = 54;
+		spritesubnumber = 3;
+	}
+
+	791
+	{
+		spritenumber = 32;
+	}
+
+	792
+	{
+		spritenumber = 32;
+		spritesubnumber = 1;
+	}
+
+	793
+	{
+		spritenumber = 32;
+		spritesubnumber = 2;
+	}
+
+	794
+	{
+		spritenumber = 32;
+		spritesubnumber = 3;
+	}
+
+	795
+	{
+		spritenumber = 32;
+		spritesubnumber = 4;
+	}
+
+	796
+	{
+		spritenumber = 32;
+		spritesubnumber = 5;
+	}
+
+	797
+	{
+		spritenumber = 32;
+		spritesubnumber = 6;
+	}
+
+	798
+	{
+		spritenumber = 32;
+		spritesubnumber = 7;
+	}
+
+	799
+	{
+		spritenumber = 22;
+		spritesubnumber = 1;
+	}
+
+	800
+	{
+		spritenumber = 22;
+		spritesubnumber = 2;
+	}
+
+	801
+	{
+		spritenumber = 22;
+		spritesubnumber = 3;
+	}
+
+	802
+	{
+		spritenumber = 55;
+	}
+
+	803
+	{
+		spritenumber = 55;
+		spritesubnumber = 1;
+	}
+
+	804
+	{
+		spritenumber = 56;
+	}
+
+	805
+	{
+		spritenumber = 56;
+		spritesubnumber = 1;
+	}
+
+	806
+	{
+		spritenumber = 57;
+	}
+
+	807
+	{
+		spritenumber = 57;
+		spritesubnumber = 1;
+	}
+
+	808
+	{
+		spritenumber = 58;
+	}
+
+	809
+	{
+		spritenumber = 58;
+		spritesubnumber = 1;
+	}
+
+	810
+	{
+		spritenumber = 58;
+		spritesubnumber = 2;
+	}
+
+	811
+	{
+		spritenumber = 58;
+		spritesubnumber = 3;
+	}
+
+	812
+	{
+		spritenumber = 58;
+		spritesubnumber = 4;
+	}
+
+	813
+	{
+		spritenumber = 59;
+	}
+
+	814
+	{
+		spritenumber = 59;
+		spritesubnumber = 1;
+	}
+
+	815
+	{
+		spritenumber = 59;
+		spritesubnumber = 2;
+	}
+
+	816
+	{
+		spritenumber = 60;
+	}
+
+	817
+	{
+		spritenumber = 60;
+		spritesubnumber = 1;
+	}
+
+	818
+	{
+		spritenumber = 60;
+		spritesubnumber = 2;
+	}
+
+	819
+	{
+		spritenumber = 60;
+		spritesubnumber = 3;
+	}
+
+	820
+	{
+		spritenumber = 60;
+		spritesubnumber = 2;
+	}
+
+	821
+	{
+		spritenumber = 60;
+		spritesubnumber = 1;
+	}
+
+	822
+	{
+		spritenumber = 61;
+	}
+
+	823
+	{
+		spritenumber = 61;
+		spritesubnumber = 1;
+	}
+
+	824
+	{
+		spritenumber = 61;
+		spritesubnumber = 2;
+	}
+
+	825
+	{
+		spritenumber = 61;
+		spritesubnumber = 3;
+	}
+
+	826
+	{
+		spritenumber = 61;
+		spritesubnumber = 2;
+	}
+
+	827
+	{
+		spritenumber = 61;
+		spritesubnumber = 1;
+	}
+
+	828
+	{
+		spritenumber = 62;
+	}
+
+	829
+	{
+		spritenumber = 62;
+		spritesubnumber = 1;
+	}
+
+	830
+	{
+		spritenumber = 63;
+	}
+
+	831
+	{
+		spritenumber = 63;
+		spritesubnumber = 1;
+	}
+
+	832
+	{
+		spritenumber = 64;
+	}
+
+	833
+	{
+		spritenumber = 64;
+		spritesubnumber = 1;
+	}
+
+	834
+	{
+		spritenumber = 65;
+	}
+
+	835
+	{
+		spritenumber = 65;
+		spritesubnumber = 1;
+	}
+
+	836
+	{
+		spritenumber = 66;
+	}
+
+	837
+	{
+		spritenumber = 66;
+		spritesubnumber = 1;
+	}
+
+	838
+	{
+		spritenumber = 67;
+	}
+
+	839
+	{
+		spritenumber = 67;
+		spritesubnumber = 1;
+	}
+
+	840
+	{
+		spritenumber = 68;
+	}
+
+	841
+	{
+		spritenumber = 69;
+	}
+
+	842
+	{
+		spritenumber = 70;
+	}
+
+	843
+	{
+		spritenumber = 70;
+		spritesubnumber = 1;
+	}
+
+	844
+	{
+		spritenumber = 70;
+		spritesubnumber = 2;
+	}
+
+	845
+	{
+		spritenumber = 70;
+		spritesubnumber = 3;
+	}
+
+	846
+	{
+		spritenumber = 70;
+		spritesubnumber = 2;
+	}
+
+	847
+	{
+		spritenumber = 70;
+		spritesubnumber = 1;
+	}
+
+	848
+	{
+		spritenumber = 71;
+	}
+
+	849
+	{
+		spritenumber = 71;
+		spritesubnumber = 1;
+	}
+
+	850
+	{
+		spritenumber = 71;
+		spritesubnumber = 2;
+	}
+
+	851
+	{
+		spritenumber = 71;
+		spritesubnumber = 3;
+	}
+
+	852
+	{
+		spritenumber = 72;
+	}
+
+	853
+	{
+		spritenumber = 73;
+	}
+
+	854
+	{
+		spritenumber = 73;
+		spritesubnumber = 1;
+	}
+
+	855
+	{
+		spritenumber = 73;
+		spritesubnumber = 2;
+	}
+
+	856
+	{
+		spritenumber = 73;
+		spritesubnumber = 3;
+	}
+
+	857
+	{
+		spritenumber = 74;
+	}
+
+	858
+	{
+		spritenumber = 74;
+		spritesubnumber = 1;
+	}
+
+	859
+	{
+		spritenumber = 74;
+		spritesubnumber = 2;
+	}
+
+	860
+	{
+		spritenumber = 74;
+		spritesubnumber = 3;
+	}
+
+	861
+	{
+		spritenumber = 75;
+	}
+
+	862
+	{
+		spritenumber = 76;
+	}
+
+	863
+	{
+		spritenumber = 76;
+		spritesubnumber = 1;
+	}
+
+	864
+	{
+		spritenumber = 76;
+		spritesubnumber = 2;
+	}
+
+	865
+	{
+		spritenumber = 76;
+		spritesubnumber = 3;
+	}
+
+	866
+	{
+		spritenumber = 76;
+		spritesubnumber = 2;
+	}
+
+	867
+	{
+		spritenumber = 76;
+		spritesubnumber = 1;
+	}
+
+	868
+	{
+		spritenumber = 77;
+	}
+
+	869
+	{
+		spritenumber = 77;
+		spritesubnumber = 1;
+	}
+
+	870
+	{
+		spritenumber = 78;
+	}
+
+	871
+	{
+		spritenumber = 79;
+	}
+
+	872
+	{
+		spritenumber = 80;
+	}
+
+	873
+	{
+		spritenumber = 81;
+	}
+
+	874
+	{
+		spritenumber = 82;
+	}
+
+	875
+	{
+		spritenumber = 83;
+	}
+
+	876
+	{
+		spritenumber = 84;
+	}
+
+	877
+	{
+		spritenumber = 85;
+	}
+
+	878
+	{
+		spritenumber = 86;
+	}
+
+	879
+	{
+		spritenumber = 87;
+	}
+
+	880
+	{
+		spritenumber = 88;
+	}
+
+	881
+	{
+		spritenumber = 89;
+	}
+
+	882
+	{
+		spritenumber = 90;
+	}
+
+	883
+	{
+		spritenumber = 91;
+	}
+
+	884
+	{
+		spritenumber = 92;
+	}
+
+	885
+	{
+		spritenumber = 93;
+	}
+
+	886
+	{
+		spritenumber = 94;
+	}
+
+	887
+	{
+		spritenumber = 95;
+	}
+
+	888
+	{
+		spritenumber = 96;
+	}
+
+	889
+	{
+		spritenumber = 96;
+		spritesubnumber = 1;
+	}
+
+	890
+	{
+		spritenumber = 96;
+		spritesubnumber = 2;
+	}
+
+	891
+	{
+		spritenumber = 96;
+		spritesubnumber = 1;
+	}
+
+	892
+	{
+		spritenumber = 28;
+		spritesubnumber = 13;
+	}
+
+	893
+	{
+		spritenumber = 28;
+		spritesubnumber = 18;
+	}
+
+	894
+	{
+		spritenumber = 97;
+	}
+
+	895
+	{
+		spritenumber = 98;
+	}
+
+	896
+	{
+		spritenumber = 99;
+	}
+
+	897
+	{
+		spritenumber = 100;
+	}
+
+	898
+	{
+		spritenumber = 100;
+		spritesubnumber = 1;
+	}
+
+	899
+	{
+		spritenumber = 101;
+	}
+
+	900
+	{
+		spritenumber = 102;
+	}
+
+	901
+	{
+		spritenumber = 102;
+		spritesubnumber = 1;
+	}
+
+	902
+	{
+		spritenumber = 103;
+	}
+
+	903
+	{
+		spritenumber = 104;
+	}
+
+	904
+	{
+		spritenumber = 105;
+	}
+
+	905
+	{
+		spritenumber = 106;
+	}
+
+	906
+	{
+		spritenumber = 107;
+	}
+
+	907
+	{
+		spritenumber = 108;
+	}
+
+	908
+	{
+		spritenumber = 109;
+	}
+
+	909
+	{
+		spritenumber = 110;
+	}
+
+	910
+	{
+		spritenumber = 111;
+	}
+
+	911
+	{
+		spritenumber = 112;
+	}
+
+	912
+	{
+		spritenumber = 113;
+	}
+
+	913
+	{
+		spritenumber = 114;
+	}
+
+	914
+	{
+		spritenumber = 115;
+	}
+
+	915
+	{
+		spritenumber = 116;
+	}
+
+	916
+	{
+		spritenumber = 117;
+	}
+
+	917
+	{
+		spritenumber = 118;
+	}
+
+	918
+	{
+		spritenumber = 118;
+		spritesubnumber = 1;
+	}
+
+	919
+	{
+		spritenumber = 118;
+		spritesubnumber = 2;
+	}
+
+	920
+	{
+		spritenumber = 118;
+		spritesubnumber = 1;
+	}
+
+	921
+	{
+		spritenumber = 119;
+	}
+
+	922
+	{
+		spritenumber = 119;
+		spritesubnumber = 1;
+	}
+
+	923
+	{
+		spritenumber = 119;
+		spritesubnumber = 2;
+	}
+
+	924
+	{
+		spritenumber = 120;
+	}
+
+	925
+	{
+		spritenumber = 120;
+		spritesubnumber = 1;
+	}
+
+	926
+	{
+		spritenumber = 121;
+	}
+
+	927
+	{
+		spritenumber = 121;
+		spritesubnumber = 1;
+	}
+
+	928
+	{
+		spritenumber = 121;
+		spritesubnumber = 2;
+	}
+
+	929
+	{
+		spritenumber = 121;
+		spritesubnumber = 3;
+	}
+
+	930
+	{
+		spritenumber = 122;
+	}
+
+	931
+	{
+		spritenumber = 122;
+		spritesubnumber = 1;
+	}
+
+	932
+	{
+		spritenumber = 122;
+		spritesubnumber = 2;
+	}
+
+	933
+	{
+		spritenumber = 122;
+		spritesubnumber = 3;
+	}
+
+	934
+	{
+		spritenumber = 123;
+	}
+
+	935
+	{
+		spritenumber = 123;
+		spritesubnumber = 1;
+	}
+
+	936
+	{
+		spritenumber = 123;
+		spritesubnumber = 2;
+	}
+
+	937
+	{
+		spritenumber = 123;
+		spritesubnumber = 3;
+	}
+
+	938
+	{
+		spritenumber = 124;
+	}
+
+	939
+	{
+		spritenumber = 124;
+		spritesubnumber = 1;
+	}
+
+	940
+	{
+		spritenumber = 124;
+		spritesubnumber = 2;
+	}
+
+	941
+	{
+		spritenumber = 124;
+		spritesubnumber = 3;
+	}
+
+	942
+	{
+		spritenumber = 125;
+	}
+
+	943
+	{
+		spritenumber = 125;
+		spritesubnumber = 1;
+	}
+
+	944
+	{
+		spritenumber = 125;
+		spritesubnumber = 2;
+	}
+
+	945
+	{
+		spritenumber = 125;
+		spritesubnumber = 3;
+	}
+
+	946
+	{
+		spritenumber = 126;
+	}
+
+	947
+	{
+		spritenumber = 126;
+		spritesubnumber = 1;
+	}
+
+	948
+	{
+		spritenumber = 126;
+		spritesubnumber = 2;
+	}
+
+	949
+	{
+		spritenumber = 126;
+		spritesubnumber = 3;
+	}
+
+	950
+	{
+		spritenumber = 127;
+	}
+
+	951
+	{
+		spritenumber = 128;
+	}
+
+	952
+	{
+		spritenumber = 129;
+	}
+
+	953
+	{
+		spritenumber = 130;
+	}
+
+	954
+	{
+		spritenumber = 131;
+	}
+
+	955
+	{
+		spritenumber = 132;
+	}
+
+	956
+	{
+		spritenumber = 133;
+	}
+
+	957
+	{
+		spritenumber = 134;
+	}
+
+	958
+	{
+		spritenumber = 135;
+	}
+
+	959
+	{
+		spritenumber = 136;
+	}
+
+	960
+	{
+		spritenumber = 136;
+		spritesubnumber = 1;
+	}
+
+	961
+	{
+		spritenumber = 136;
+		spritesubnumber = 2;
+	}
+
+	962
+	{
+		spritenumber = 136;
+		spritesubnumber = 3;
+	}
+
+	963
+	{
+		spritenumber = 137;
+	}
+
+	964
+	{
+		spritenumber = 137;
+		spritesubnumber = 1;
+	}
+
+	965
+	{
+		spritenumber = 137;
+		spritesubnumber = 2;
+	}
+
+	966
+	{
+		spritenumber = 137;
+		spritesubnumber = 3;
+	}
+
+	968
+	{
+		spritenumber = 22;
+		spritesubnumber = 1;
+	}
+
+	969
+	{
+		spritenumber = 22;
+		spritesubnumber = 1;
+	}
+
+	970
+	{
+		spritenumber = 22;
+		spritesubnumber = 2;
+	}
+
+	971
+	{
+		spritenumber = 22;
+		spritesubnumber = 3;
+	}
+
+	972
+	{
+		spritenumber = 139;
+	}
+
+	973
+	{
+		spritenumber = 139;
+		spritesubnumber = 1;
+	}
+
+	974
+	{
+		spritenumber = 139;
+	}
+
+	975
+	{
+		spritenumber = 139;
+	}
+
+	976
+	{
+		spritenumber = 139;
+		spritesubnumber = 1;
+	}
+
+	977
+	{
+		spritenumber = 139;
+		spritesubnumber = 1;
+	}
+
+	978
+	{
+		spritenumber = 139;
+		spritesubnumber = 2;
+	}
+
+	979
+	{
+		spritenumber = 139;
+		spritesubnumber = 2;
+	}
+
+	980
+	{
+		spritenumber = 139;
+		spritesubnumber = 3;
+	}
+
+	981
+	{
+		spritenumber = 139;
+		spritesubnumber = 3;
+	}
+
+	982
+	{
+		spritenumber = 139;
+		spritesubnumber = 4;
+	}
+
+	983
+	{
+		spritenumber = 139;
+		spritesubnumber = 5;
+	}
+
+	984
+	{
+		spritenumber = 139;
+		spritesubnumber = 6;
+	}
+
+	985
+	{
+		spritenumber = 139;
+		spritesubnumber = 7;
+	}
+
+	986
+	{
+		spritenumber = 139;
+		spritesubnumber = 7;
+	}
+
+	987
+	{
+		spritenumber = 139;
+		spritesubnumber = 8;
+	}
+
+	988
+	{
+		spritenumber = 139;
+		spritesubnumber = 9;
+	}
+
+	989
+	{
+		spritenumber = 139;
+		spritesubnumber = 10;
+	}
+
+	990
+	{
+		spritenumber = 139;
+		spritesubnumber = 11;
+	}
+
+	991
+	{
+		spritenumber = 139;
+		spritesubnumber = 12;
+	}
+
+	992
+	{
+		spritenumber = 139;
+		spritesubnumber = 13;
+	}
+
+	993
+	{
+		spritenumber = 139;
+		spritesubnumber = 13;
+	}
+
+	994
+	{
+		spritenumber = 139;
+		spritesubnumber = 12;
+	}
+
+	995
+	{
+		spritenumber = 139;
+		spritesubnumber = 11;
+	}
+
+	996
+	{
+		spritenumber = 139;
+		spritesubnumber = 10;
+	}
+
+	997
+	{
+		spritenumber = 139;
+		spritesubnumber = 9;
+	}
+
+	998
+	{
+		spritenumber = 139;
+		spritesubnumber = 8;
+	}
+
+	999
+	{
+		spritenumber = 14;
+	}
+
+	1000
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1001
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1002
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1003
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1004
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1005
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1006
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1007
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1008
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1009
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1010
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1011
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1012
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1013
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1014
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1015
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1016
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1017
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1018
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1019
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1020
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1021
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1022
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1023
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1024
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1025
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1026
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1027
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1028
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1029
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1030
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1031
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1032
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1033
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1034
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1035
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1036
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1037
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1038
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1039
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1040
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1041
+	{
+		spritenumber = 14;
+		spritesubnumber = 1;
+	}
+
+	1042
+	{
+		spritenumber = 140;
+	}
+
+	1043
+	{
+		spritenumber = 140;
+		spritesubnumber = 1;
+	}
+
+	1044
+	{
+		spritenumber = 140;
+		spritesubnumber = 2;
+	}
+
+	1045
+	{
+		spritenumber = 140;
+		spritesubnumber = 3;
+	}
+
+	1046
+	{
+		spritenumber = 140;
+		spritesubnumber = 4;
+	}
+
+	1047
+	{
+		spritenumber = 140;
+		spritesubnumber = 5;
+	}
+
+	1048
+	{
+		spritenumber = 140;
+		spritesubnumber = 6;
+	}
+
+	1049
+	{
+		spritenumber = 141;
+	}
+
+	1050
+	{
+		spritenumber = 141;
+		spritesubnumber = 1;
+	}
+
+	1051
+	{
+		spritenumber = 141;
+		spritesubnumber = 2;
+	}
+
+	1052
+	{
+		spritenumber = 141;
+		spritesubnumber = 3;
+	}
+
+	1053
+	{
+		spritenumber = 141;
+		spritesubnumber = 4;
+	}
+
+	1054
+	{
+		spritenumber = 142;
+	}
+
+	1055
+	{
+		spritenumber = 143;
+	}
+
+	1056
+	{
+		spritenumber = 44;
+	}
+
+	1057
+	{
+		spritenumber = 44;
+		spritesubnumber = 1;
+	}
+
+	1058
+	{
+		spritenumber = 44;
+		spritesubnumber = 2;
+	}
+
+	1059
+	{
+		spritenumber = 44;
+		spritesubnumber = 3;
+	}
+
+	1060
+	{
+		spritenumber = 44;
+	}
+
+	1061
+	{
+		spritenumber = 44;
+		spritesubnumber = 4;
+	}
+
+	1062
+	{
+		spritenumber = 44;
+		spritesubnumber = 5;
+	}
+
+	1063
+	{
+		spritenumber = 44;
+		spritesubnumber = 5;
+	}
+
+	1064
+	{
+		spritenumber = 44;
+		spritesubnumber = 6;
+	}
+
+	1065
+	{
+		spritenumber = 44;
+		spritesubnumber = 7;
+	}
+
+	1066
+	{
+		spritenumber = 44;
+		spritesubnumber = 8;
+	}
+
+	1067
+	{
+		spritenumber = 44;
+		spritesubnumber = 9;
+	}
+
+	1068
+	{
+		spritenumber = 44;
+		spritesubnumber = 10;
+	}
+
+	1069
+	{
+		spritenumber = 44;
+		spritesubnumber = 11;
+	}
+
+	1070
+	{
+		spritenumber = 44;
+		spritesubnumber = 12;
+	}
+
+	1071
+	{
+		spritenumber = 44;
+		spritesubnumber = 13;
+	}
+
+	1072
+	{
+		spritenumber = 44;
+		spritesubnumber = 14;
+	}
+
+	1073
+	{
+		spritenumber = 44;
+		spritesubnumber = 15;
+	}
+
+	1074
+	{
+		spritenumber = 44;
+		spritesubnumber = 16;
+	}
+
+	1075
+	{
+		spritenumber = 22;
+		spritesubnumber = 1;
+	}
+
+	1076
+	{
+		spritenumber = 58;
+	}
+
+	1077
+	{
+		spritenumber = 144;
+	}
+
+	1078
+	{
+		spritenumber = 144;
+		spritesubnumber = 1;
+	}
+
+	1079
+	{
+		spritenumber = 144;
+		spritesubnumber = 2;
+	}
+
+	1080
+	{
+		spritenumber = 144;
+		spritesubnumber = 3;
+	}
+
+	1081
+	{
+		spritenumber = 144;
+		spritesubnumber = 4;
+	}
+
+	1082
+	{
+		spritenumber = 144;
+		spritesubnumber = 5;
+	}
+
+	1083
+	{
+		spritenumber = 144;
+		spritesubnumber = 6;
+	}
+
+	1084
+	{
+		spritenumber = 144;
+		spritesubnumber = 7;
+	}
+
+	1085
+	{
+		spritenumber = 17;
+	}
+
+	1086
+	{
+		spritenumber = 17;
+		spritesubnumber = 1;
+	}
+
+	1087
+	{
+		spritenumber = 17;
+		spritesubnumber = 2;
+	}
+
+	1088
+	{
+		spritenumber = 17;
+		spritesubnumber = 3;
+	}
+
+}
+
+
+sprites
+{
+	0 = "TROO";
+	1 = "SHTG";
+	2 = "PUNG";
+	3 = "PISG";
+	4 = "PISF";
+	5 = "SHTF";
+	6 = "SHT2";
+	7 = "CHGG";
+	8 = "CHGF";
+	9 = "MISG";
+	10 = "MISF";
+	11 = "SAWG";
+	12 = "PLSG";
+	13 = "PLSF";
+	14 = "BFGG";
+	15 = "BFGF";
+	16 = "BLUD";
+	17 = "PUFF";
+	18 = "BAL1";
+	19 = "BAL2";
+	20 = "PLSS";
+	21 = "PLSE";
+	22 = "MISL";
+	23 = "BFS1";
+	24 = "BFE1";
+	25 = "BFE2";
+	26 = "TFOG";
+	27 = "IFOG";
+	28 = "PLAY";
+	29 = "POSS";
+	30 = "SPOS";
+	31 = "VILE";
+	32 = "FIRE";
+	33 = "FATB";
+	34 = "FBXP";
+	35 = "SKEL";
+	36 = "MANF";
+	37 = "FATT";
+	38 = "CPOS";
+	39 = "SARG";
+	40 = "HEAD";
+	41 = "BAL7";
+	42 = "BOSS";
+	43 = "BOS2";
+	44 = "SKUL";
+	45 = "SPID";
+	46 = "BSPI";
+	47 = "APLS";
+	48 = "APBX";
+	49 = "CYBR";
+	50 = "PAIN";
+	51 = "SSWV";
+	52 = "KEEN";
+	53 = "BBRN";
+	54 = "BOSF";
+	55 = "ARM1";
+	56 = "ARM2";
+	57 = "BAR1";
+	58 = "BEXP";
+	59 = "FCAN";
+	60 = "BON1";
+	61 = "BON2";
+	62 = "BKEY";
+	63 = "RKEY";
+	64 = "YKEY";
+	65 = "BSKU";
+	66 = "RSKU";
+	67 = "YSKU";
+	68 = "STIM";
+	69 = "MEDI";
+	70 = "SOUL";
+	71 = "PINV";
+	72 = "PSTR";
+	73 = "PINS";
+	74 = "MEGA";
+	75 = "SUIT";
+	76 = "PMAP";
+	77 = "PVIS";
+	78 = "CLIP";
+	79 = "AMMO";
+	80 = "ROCK";
+	81 = "BROK";
+	82 = "CELL";
+	83 = "CELP";
+	84 = "SHEL";
+	85 = "SBOX";
+	86 = "BPAK";
+	87 = "BFUG";
+	88 = "MGUN";
+	89 = "CSAW";
+	90 = "LAUN";
+	91 = "PLAS";
+	92 = "SHOT";
+	93 = "SGN2";
+	94 = "COLU";
+	95 = "SMT2";
+	96 = "GOR1";
+	97 = "POL2";
+	98 = "POL5";
+	99 = "POL4";
+	100 = "POL3";
+	101 = "POL1";
+	102 = "POL6";
+	103 = "GOR2";
+	104 = "GOR3";
+	105 = "GOR4";
+	106 = "GOR5";
+	107 = "SMIT";
+	108 = "COL1";
+	109 = "COL2";
+	110 = "COL3";
+	111 = "COL4";
+	112 = "CAND";
+	113 = "CBRA";
+	114 = "COL6";
+	115 = "TRE1";
+	116 = "TRE2";
+	117 = "ELEC";
+	118 = "CEYE";
+	119 = "FSKU";
+	120 = "COL5";
+	121 = "TBLU";
+	122 = "TGRN";
+	123 = "TRED";
+	124 = "SMBT";
+	125 = "SMGT";
+	126 = "SMRT";
+	127 = "HDB1";
+	128 = "HDB2";
+	129 = "HDB3";
+	130 = "HDB4";
+	131 = "HDB5";
+	132 = "HDB6";
+	133 = "POB1";
+	134 = "POB2";
+	135 = "BRS1";
+	136 = "TLMP";
+	137 = "TLP2";
+	138 = "TNT1";
+	139 = "DOGS";
+	140 = "PLS1";
+	141 = "PLS2";
+	142 = "BON3";
+	143 = "BON4";
+	144 = "BLD2";
+	145 = "SP00";
+	146 = "SP01";
+	147 = "SP02";
+	148 = "SP03";
+	149 = "SP04";
+	150 = "SP05";
+	151 = "SP06";
+	152 = "SP07";
+	153 = "SP08";
+	154 = "SP09";
+	155 = "SP10";
+	156 = "SP11";
+	157 = "SP12";
+	158 = "SP13";
+	159 = "SP14";
+	160 = "SP15";
+	161 = "SP16";
+	162 = "SP17";
+	163 = "SP18";
+	164 = "SP19";
+	165 = "SP20";
+	166 = "SP21";
+	167 = "SP22";
+	168 = "SP23";
+	169 = "SP24";
+	170 = "SP25";
+	171 = "SP26";
+	172 = "SP27";
+	173 = "SP28";
+	174 = "SP29";
+	175 = "SP30";
+	176 = "SP31";
+	177 = "SP32";
+	178 = "SP33";
+	179 = "SP34";
+	180 = "SP35";
+	181 = "SP36";
+	182 = "SP37";
+	183 = "SP38";
+	184 = "SP39";
+	185 = "SP40";
+	186 = "SP41";
+	187 = "SP42";
+	188 = "SP43";
+	189 = "SP44";
+	190 = "SP45";
+	191 = "SP46";
+	192 = "SP47";
+	193 = "SP48";
+	194 = "SP49";
+	195 = "SP50";
+	196 = "SP51";
+	197 = "SP52";
+	198 = "SP53";
+	199 = "SP54";
+	200 = "SP55";
+	201 = "SP56";
+	202 = "SP57";
+	203 = "SP58";
+	204 = "SP59";
+	205 = "SP60";
+	206 = "SP61";
+	207 = "SP62";
+	208 = "SP63";
+	209 = "SP64";
+	210 = "SP65";
+	211 = "SP66";
+	212 = "SP67";
+	213 = "SP68";
+	214 = "SP69";
+	215 = "SP70";
+	216 = "SP71";
+	217 = "SP72";
+	218 = "SP73";
+	219 = "SP74";
+	220 = "SP75";
+	221 = "SP76";
+	222 = "SP77";
+	223 = "SP78";
+	224 = "SP79";
+	225 = "SP80";
+	226 = "SP81";
+	227 = "SP82";
+	228 = "SP83";
+	229 = "SP84";
+	230 = "SP85";
+	231 = "SP86";
+	232 = "SP87";
+	233 = "SP88";
+	234 = "SP89";
+	235 = "SP90";
+	236 = "SP91";
+	237 = "SP92";
+	238 = "SP93";
+	239 = "SP94";
+	240 = "SP95";
+	241 = "SP96";
+	242 = "SP97";
+	243 = "SP98";
+	244 = "SP99";
+}
+

--- a/Build/Configurations/Includes/Dehacked_Doom.cfg
+++ b/Build/Configurations/Includes/Dehacked_Doom.cfg
@@ -1938,7 +1938,6 @@ things
 
 }
 
-
 frames
 {
 	// WhackEd defaults to 138
@@ -2044,6 +2043,7 @@ frames
 	17
 	{
 		spritenumber = 4;
+		bright = true;
 	}
 
 	18
@@ -2114,12 +2114,14 @@ frames
 	30
 	{
 		spritenumber = 5;
+		bright = true;
 	}
 
 	31
 	{
 		spritenumber = 5;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	32
@@ -2209,12 +2211,14 @@ frames
 	{
 		spritenumber = 6;
 		spritesubnumber = 8;
+		bright = true;
 	}
 
 	48
 	{
 		spritenumber = 6;
 		spritesubnumber = 9;
+		bright = true;
 	}
 
 	49
@@ -2252,12 +2256,14 @@ frames
 	55
 	{
 		spritenumber = 8;
+		bright = true;
 	}
 
 	56
 	{
 		spritenumber = 8;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	57
@@ -2296,24 +2302,28 @@ frames
 	63
 	{
 		spritenumber = 10;
+		bright = true;
 	}
 
 	64
 	{
 		spritenumber = 10;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	65
 	{
 		spritenumber = 10;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	66
 	{
 		spritenumber = 10;
 		spritesubnumber = 3;
+		bright = true;
 	}
 
 	67
@@ -2386,12 +2396,14 @@ frames
 	79
 	{
 		spritenumber = 13;
+		bright = true;
 	}
 
 	80
 	{
 		spritenumber = 13;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	81
@@ -2435,12 +2447,14 @@ frames
 	88
 	{
 		spritenumber = 15;
+		bright = true;
 	}
 
 	89
 	{
 		spritenumber = 15;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	90
@@ -2463,6 +2477,7 @@ frames
 	93
 	{
 		spritenumber = 17;
+		bright = true;
 	}
 
 	94
@@ -2486,301 +2501,353 @@ frames
 	97
 	{
 		spritenumber = 18;
+		bright = true;
 	}
 
 	98
 	{
 		spritenumber = 18;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	99
 	{
 		spritenumber = 18;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	100
 	{
 		spritenumber = 18;
 		spritesubnumber = 3;
+		bright = true;
 	}
 
 	101
 	{
 		spritenumber = 18;
 		spritesubnumber = 4;
+		bright = true;
 	}
 
 	102
 	{
 		spritenumber = 19;
+		bright = true;
 	}
 
 	103
 	{
 		spritenumber = 19;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	104
 	{
 		spritenumber = 19;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	105
 	{
 		spritenumber = 19;
 		spritesubnumber = 3;
+		bright = true;
 	}
 
 	106
 	{
 		spritenumber = 19;
 		spritesubnumber = 4;
+		bright = true;
 	}
 
 	107
 	{
 		spritenumber = 20;
+		bright = true;
 	}
 
 	108
 	{
 		spritenumber = 20;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	109
 	{
 		spritenumber = 21;
+		bright = true;
 	}
 
 	110
 	{
 		spritenumber = 21;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	111
 	{
 		spritenumber = 21;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	112
 	{
 		spritenumber = 21;
 		spritesubnumber = 3;
+		bright = true;
 	}
 
 	113
 	{
 		spritenumber = 21;
 		spritesubnumber = 4;
+		bright = true;
 	}
 
 	114
 	{
 		spritenumber = 22;
+		bright = true;
 	}
 
 	115
 	{
 		spritenumber = 23;
+		bright = true;
 	}
 
 	116
 	{
 		spritenumber = 23;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	117
 	{
 		spritenumber = 24;
+		bright = true;
 	}
 
 	118
 	{
 		spritenumber = 24;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	119
 	{
 		spritenumber = 24;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	120
 	{
 		spritenumber = 24;
 		spritesubnumber = 3;
+		bright = true;
 	}
 
 	121
 	{
 		spritenumber = 24;
 		spritesubnumber = 4;
+		bright = true;
 	}
 
 	122
 	{
 		spritenumber = 24;
 		spritesubnumber = 5;
+		bright = true;
 	}
 
 	123
 	{
 		spritenumber = 25;
+		bright = true;
 	}
 
 	124
 	{
 		spritenumber = 25;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	125
 	{
 		spritenumber = 25;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	126
 	{
 		spritenumber = 25;
 		spritesubnumber = 3;
+		bright = true;
 	}
 
 	127
 	{
 		spritenumber = 22;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	128
 	{
 		spritenumber = 22;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	129
 	{
 		spritenumber = 22;
 		spritesubnumber = 3;
+		bright = true;
 	}
 
 	130
 	{
 		spritenumber = 26;
+		bright = true;
 	}
 
 	131
 	{
 		spritenumber = 26;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	132
 	{
 		spritenumber = 26;
+		bright = true;
 	}
 
 	133
 	{
 		spritenumber = 26;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	134
 	{
 		spritenumber = 26;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	135
 	{
 		spritenumber = 26;
 		spritesubnumber = 3;
+		bright = true;
 	}
 
 	136
 	{
 		spritenumber = 26;
 		spritesubnumber = 4;
+		bright = true;
 	}
 
 	137
 	{
 		spritenumber = 26;
 		spritesubnumber = 5;
+		bright = true;
 	}
 
 	138
 	{
 		spritenumber = 26;
 		spritesubnumber = 6;
+		bright = true;
 	}
 
 	139
 	{
 		spritenumber = 26;
 		spritesubnumber = 7;
+		bright = true;
 	}
 
 	140
 	{
 		spritenumber = 26;
 		spritesubnumber = 8;
+		bright = true;
 	}
 
 	141
 	{
 		spritenumber = 26;
 		spritesubnumber = 9;
+		bright = true;
 	}
 
 	142
 	{
 		spritenumber = 27;
+		bright = true;
 	}
 
 	143
 	{
 		spritenumber = 27;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	144
 	{
 		spritenumber = 27;
+		bright = true;
 	}
 
 	145
 	{
 		spritenumber = 27;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	146
 	{
 		spritenumber = 27;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	147
 	{
 		spritenumber = 27;
 		spritesubnumber = 3;
+		bright = true;
 	}
 
 	148
 	{
 		spritenumber = 27;
 		spritesubnumber = 4;
+		bright = true;
 	}
 
 	149
@@ -2821,6 +2888,7 @@ frames
 	{
 		spritenumber = 28;
 		spritesubnumber = 5;
+		bright = true;
 	}
 
 	156
@@ -3193,6 +3261,7 @@ frames
 	{
 		spritenumber = 30;
 		spritesubnumber = 5;
+		bright = true;
 	}
 
 	219
@@ -3412,84 +3481,98 @@ frames
 	{
 		spritenumber = 31;
 		spritesubnumber = 6;
+		bright = true;
 	}
 
 	256
 	{
 		spritenumber = 31;
 		spritesubnumber = 6;
+		bright = true;
 	}
 
 	257
 	{
 		spritenumber = 31;
 		spritesubnumber = 7;
+		bright = true;
 	}
 
 	258
 	{
 		spritenumber = 31;
 		spritesubnumber = 8;
+		bright = true;
 	}
 
 	259
 	{
 		spritenumber = 31;
 		spritesubnumber = 9;
+		bright = true;
 	}
 
 	260
 	{
 		spritenumber = 31;
 		spritesubnumber = 10;
+		bright = true;
 	}
 
 	261
 	{
 		spritenumber = 31;
 		spritesubnumber = 11;
+		bright = true;
 	}
 
 	262
 	{
 		spritenumber = 31;
 		spritesubnumber = 12;
+		bright = true;
 	}
 
 	263
 	{
 		spritenumber = 31;
 		spritesubnumber = 13;
+		bright = true;
 	}
 
 	264
 	{
 		spritenumber = 31;
 		spritesubnumber = 14;
+		bright = true;
 	}
 
 	265
 	{
 		spritenumber = 31;
 		spritesubnumber = 15;
+		bright = true;
 	}
 
 	266
 	{
 		spritenumber = 31;
 		spritesubnumber = 26;
+		bright = true;
 	}
 
 	267
 	{
 		spritenumber = 31;
 		spritesubnumber = 27;
+		bright = true;
 	}
 
 	268
 	{
 		spritenumber = 31;
 		spritesubnumber = 28;
+		bright = true;
 	}
 
 	269
@@ -3567,179 +3650,209 @@ frames
 	281
 	{
 		spritenumber = 32;
+		bright = true;
 	}
 
 	282
 	{
 		spritenumber = 32;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	283
 	{
 		spritenumber = 32;
+		bright = true;
 	}
 
 	284
 	{
 		spritenumber = 32;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	285
 	{
 		spritenumber = 32;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	286
 	{
 		spritenumber = 32;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	287
 	{
 		spritenumber = 32;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	288
 	{
 		spritenumber = 32;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	289
 	{
 		spritenumber = 32;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	290
 	{
 		spritenumber = 32;
 		spritesubnumber = 3;
+		bright = true;
 	}
 
 	291
 	{
 		spritenumber = 32;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	292
 	{
 		spritenumber = 32;
 		spritesubnumber = 3;
+		bright = true;
 	}
 
 	293
 	{
 		spritenumber = 32;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	294
 	{
 		spritenumber = 32;
 		spritesubnumber = 3;
+		bright = true;
 	}
 
 	295
 	{
 		spritenumber = 32;
 		spritesubnumber = 4;
+		bright = true;
 	}
 
 	296
 	{
 		spritenumber = 32;
 		spritesubnumber = 3;
+		bright = true;
 	}
 
 	297
 	{
 		spritenumber = 32;
 		spritesubnumber = 4;
+		bright = true;
 	}
 
 	298
 	{
 		spritenumber = 32;
 		spritesubnumber = 3;
+		bright = true;
 	}
 
 	299
 	{
 		spritenumber = 32;
 		spritesubnumber = 4;
+		bright = true;
 	}
 
 	300
 	{
 		spritenumber = 32;
 		spritesubnumber = 5;
+		bright = true;
 	}
 
 	301
 	{
 		spritenumber = 32;
 		spritesubnumber = 4;
+		bright = true;
 	}
 
 	302
 	{
 		spritenumber = 32;
 		spritesubnumber = 5;
+		bright = true;
 	}
 
 	303
 	{
 		spritenumber = 32;
 		spritesubnumber = 4;
+		bright = true;
 	}
 
 	304
 	{
 		spritenumber = 32;
 		spritesubnumber = 5;
+		bright = true;
 	}
 
 	305
 	{
 		spritenumber = 32;
 		spritesubnumber = 6;
+		bright = true;
 	}
 
 	306
 	{
 		spritenumber = 32;
 		spritesubnumber = 7;
+		bright = true;
 	}
 
 	307
 	{
 		spritenumber = 32;
 		spritesubnumber = 6;
+		bright = true;
 	}
 
 	308
 	{
 		spritenumber = 32;
 		spritesubnumber = 7;
+		bright = true;
 	}
 
 	309
 	{
 		spritenumber = 32;
 		spritesubnumber = 6;
+		bright = true;
 	}
 
 	310
 	{
 		spritenumber = 32;
 		spritesubnumber = 7;
+		bright = true;
 	}
 
 	311
@@ -3775,29 +3888,34 @@ frames
 	316
 	{
 		spritenumber = 33;
+		bright = true;
 	}
 
 	317
 	{
 		spritenumber = 33;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	318
 	{
 		spritenumber = 34;
+		bright = true;
 	}
 
 	319
 	{
 		spritenumber = 34;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	320
 	{
 		spritenumber = 34;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	321
@@ -3909,12 +4027,14 @@ frames
 	{
 		spritenumber = 35;
 		spritesubnumber = 9;
+		bright = true;
 	}
 
 	340
 	{
 		spritenumber = 35;
 		spritesubnumber = 9;
+		bright = true;
 	}
 
 	341
@@ -4016,30 +4136,35 @@ frames
 	357
 	{
 		spritenumber = 36;
+		bright = true;
 	}
 
 	358
 	{
 		spritenumber = 36;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	359
 	{
 		spritenumber = 22;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	360
 	{
 		spritenumber = 22;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	361
 	{
 		spritenumber = 22;
 		spritesubnumber = 3;
+		bright = true;
 	}
 
 	362
@@ -4133,6 +4258,7 @@ frames
 	{
 		spritenumber = 37;
 		spritesubnumber = 7;
+		bright = true;
 	}
 
 	378
@@ -4151,6 +4277,7 @@ frames
 	{
 		spritenumber = 37;
 		spritesubnumber = 7;
+		bright = true;
 	}
 
 	381
@@ -4169,6 +4296,7 @@ frames
 	{
 		spritenumber = 37;
 		spritesubnumber = 7;
+		bright = true;
 	}
 
 	384
@@ -4370,12 +4498,14 @@ frames
 	{
 		spritenumber = 38;
 		spritesubnumber = 5;
+		bright = true;
 	}
 
 	418
 	{
 		spritenumber = 38;
 		spritesubnumber = 4;
+		bright = true;
 	}
 
 	419
@@ -4896,6 +5026,7 @@ frames
 	{
 		spritenumber = 40;
 		spritesubnumber = 3;
+		bright = true;
 	}
 
 	507
@@ -4991,30 +5122,35 @@ frames
 	522
 	{
 		spritenumber = 41;
+		bright = true;
 	}
 
 	523
 	{
 		spritenumber = 41;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	524
 	{
 		spritenumber = 41;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	525
 	{
 		spritenumber = 41;
 		spritesubnumber = 3;
+		bright = true;
 	}
 
 	526
 	{
 		spritenumber = 41;
 		spritesubnumber = 4;
+		bright = true;
 	}
 
 	527
@@ -5362,83 +5498,97 @@ frames
 	585
 	{
 		spritenumber = 44;
+		bright = true;
 	}
 
 	586
 	{
 		spritenumber = 44;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	587
 	{
 		spritenumber = 44;
+		bright = true;
 	}
 
 	588
 	{
 		spritenumber = 44;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	589
 	{
 		spritenumber = 44;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	590
 	{
 		spritenumber = 44;
 		spritesubnumber = 3;
+		bright = true;
 	}
 
 	591
 	{
 		spritenumber = 44;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	592
 	{
 		spritenumber = 44;
 		spritesubnumber = 3;
+		bright = true;
 	}
 
 	593
 	{
 		spritenumber = 44;
 		spritesubnumber = 4;
+		bright = true;
 	}
 
 	594
 	{
 		spritenumber = 44;
 		spritesubnumber = 4;
+		bright = true;
 	}
 
 	595
 	{
 		spritenumber = 44;
 		spritesubnumber = 5;
+		bright = true;
 	}
 
 	596
 	{
 		spritenumber = 44;
 		spritesubnumber = 6;
+		bright = true;
 	}
 
 	597
 	{
 		spritenumber = 44;
 		spritesubnumber = 7;
+		bright = true;
 	}
 
 	598
 	{
 		spritenumber = 44;
 		spritesubnumber = 8;
+		bright = true;
 	}
 
 	599
@@ -5537,24 +5687,28 @@ frames
 	615
 	{
 		spritenumber = 45;
+		bright = true;
 	}
 
 	616
 	{
 		spritenumber = 45;
 		spritesubnumber = 6;
+		bright = true;
 	}
 
 	617
 	{
 		spritenumber = 45;
 		spritesubnumber = 7;
+		bright = true;
 	}
 
 	618
 	{
 		spritenumber = 45;
 		spritesubnumber = 7;
+		bright = true;
 	}
 
 	619
@@ -5724,24 +5878,28 @@ frames
 	647
 	{
 		spritenumber = 46;
+		bright = true;
 	}
 
 	648
 	{
 		spritenumber = 46;
 		spritesubnumber = 6;
+		bright = true;
 	}
 
 	649
 	{
 		spritenumber = 46;
 		spritesubnumber = 7;
+		bright = true;
 	}
 
 	650
 	{
 		spritenumber = 46;
 		spritesubnumber = 7;
+		bright = true;
 	}
 
 	651
@@ -5843,41 +6001,48 @@ frames
 	667
 	{
 		spritenumber = 47;
+		bright = true;
 	}
 
 	668
 	{
 		spritenumber = 47;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	669
 	{
 		spritenumber = 48;
+		bright = true;
 	}
 
 	670
 	{
 		spritenumber = 48;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	671
 	{
 		spritenumber = 48;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	672
 	{
 		spritenumber = 48;
 		spritesubnumber = 3;
+		bright = true;
 	}
 
 	673
 	{
 		spritenumber = 48;
 		spritesubnumber = 4;
+		bright = true;
 	}
 
 	674
@@ -6094,12 +6259,14 @@ frames
 	{
 		spritenumber = 50;
 		spritesubnumber = 5;
+		bright = true;
 	}
 
 	711
 	{
 		spritenumber = 50;
 		spritesubnumber = 5;
+		bright = true;
 	}
 
 	712
@@ -6118,36 +6285,42 @@ frames
 	{
 		spritenumber = 50;
 		spritesubnumber = 7;
+		bright = true;
 	}
 
 	715
 	{
 		spritenumber = 50;
 		spritesubnumber = 8;
+		bright = true;
 	}
 
 	716
 	{
 		spritenumber = 50;
 		spritesubnumber = 9;
+		bright = true;
 	}
 
 	717
 	{
 		spritenumber = 50;
 		spritesubnumber = 10;
+		bright = true;
 	}
 
 	718
 	{
 		spritenumber = 50;
 		spritesubnumber = 11;
+		bright = true;
 	}
 
 	719
 	{
 		spritenumber = 50;
 		spritesubnumber = 12;
+		bright = true;
 	}
 
 	720
@@ -6259,6 +6432,7 @@ frames
 	{
 		spritenumber = 51;
 		spritesubnumber = 6;
+		bright = true;
 	}
 
 	739
@@ -6271,6 +6445,7 @@ frames
 	{
 		spritenumber = 51;
 		spritesubnumber = 6;
+		bright = true;
 	}
 
 	741
@@ -6542,89 +6717,104 @@ frames
 	787
 	{
 		spritenumber = 54;
+		bright = true;
 	}
 
 	788
 	{
 		spritenumber = 54;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	789
 	{
 		spritenumber = 54;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	790
 	{
 		spritenumber = 54;
 		spritesubnumber = 3;
+		bright = true;
 	}
 
 	791
 	{
 		spritenumber = 32;
+		bright = true;
 	}
 
 	792
 	{
 		spritenumber = 32;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	793
 	{
 		spritenumber = 32;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	794
 	{
 		spritenumber = 32;
 		spritesubnumber = 3;
+		bright = true;
 	}
 
 	795
 	{
 		spritenumber = 32;
 		spritesubnumber = 4;
+		bright = true;
 	}
 
 	796
 	{
 		spritenumber = 32;
 		spritesubnumber = 5;
+		bright = true;
 	}
 
 	797
 	{
 		spritenumber = 32;
 		spritesubnumber = 6;
+		bright = true;
 	}
 
 	798
 	{
 		spritenumber = 32;
 		spritesubnumber = 7;
+		bright = true;
 	}
 
 	799
 	{
 		spritenumber = 22;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	800
 	{
 		spritenumber = 22;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	801
 	{
 		spritenumber = 22;
 		spritesubnumber = 3;
+		bright = true;
 	}
 
 	802
@@ -6636,6 +6826,7 @@ frames
 	{
 		spritenumber = 55;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	804
@@ -6647,6 +6838,7 @@ frames
 	{
 		spritenumber = 56;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	806
@@ -6663,47 +6855,55 @@ frames
 	808
 	{
 		spritenumber = 58;
+		bright = true;
 	}
 
 	809
 	{
 		spritenumber = 58;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	810
 	{
 		spritenumber = 58;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	811
 	{
 		spritenumber = 58;
 		spritesubnumber = 3;
+		bright = true;
 	}
 
 	812
 	{
 		spritenumber = 58;
 		spritesubnumber = 4;
+		bright = true;
 	}
 
 	813
 	{
 		spritenumber = 59;
+		bright = true;
 	}
 
 	814
 	{
 		spritenumber = 59;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	815
 	{
 		spritenumber = 59;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	816
@@ -6785,6 +6985,7 @@ frames
 	{
 		spritenumber = 62;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	830
@@ -6796,6 +6997,7 @@ frames
 	{
 		spritenumber = 63;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	832
@@ -6807,6 +7009,7 @@ frames
 	{
 		spritenumber = 64;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	834
@@ -6818,6 +7021,7 @@ frames
 	{
 		spritenumber = 65;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	836
@@ -6829,6 +7033,7 @@ frames
 	{
 		spritenumber = 66;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	838
@@ -6840,6 +7045,7 @@ frames
 	{
 		spritenumber = 67;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	840
@@ -6855,155 +7061,182 @@ frames
 	842
 	{
 		spritenumber = 70;
+		bright = true;
 	}
 
 	843
 	{
 		spritenumber = 70;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	844
 	{
 		spritenumber = 70;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	845
 	{
 		spritenumber = 70;
 		spritesubnumber = 3;
+		bright = true;
 	}
 
 	846
 	{
 		spritenumber = 70;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	847
 	{
 		spritenumber = 70;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	848
 	{
 		spritenumber = 71;
+		bright = true;
 	}
 
 	849
 	{
 		spritenumber = 71;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	850
 	{
 		spritenumber = 71;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	851
 	{
 		spritenumber = 71;
 		spritesubnumber = 3;
+		bright = true;
 	}
 
 	852
 	{
 		spritenumber = 72;
+		bright = true;
 	}
 
 	853
 	{
 		spritenumber = 73;
+		bright = true;
 	}
 
 	854
 	{
 		spritenumber = 73;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	855
 	{
 		spritenumber = 73;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	856
 	{
 		spritenumber = 73;
 		spritesubnumber = 3;
+		bright = true;
 	}
 
 	857
 	{
 		spritenumber = 74;
+		bright = true;
 	}
 
 	858
 	{
 		spritenumber = 74;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	859
 	{
 		spritenumber = 74;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	860
 	{
 		spritenumber = 74;
 		spritesubnumber = 3;
+		bright = true;
 	}
 
 	861
 	{
 		spritenumber = 75;
+		bright = true;
 	}
 
 	862
 	{
 		spritenumber = 76;
+		bright = true;
 	}
 
 	863
 	{
 		spritenumber = 76;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	864
 	{
 		spritenumber = 76;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	865
 	{
 		spritenumber = 76;
 		spritesubnumber = 3;
+		bright = true;
 	}
 
 	866
 	{
 		spritenumber = 76;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	867
 	{
 		spritenumber = 76;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	868
 	{
 		spritenumber = 77;
+		bright = true;
 	}
 
 	869
@@ -7095,6 +7328,7 @@ frames
 	886
 	{
 		spritenumber = 94;
+		bright = true;
 	}
 
 	887
@@ -7155,12 +7389,14 @@ frames
 	897
 	{
 		spritenumber = 100;
+		bright = true;
 	}
 
 	898
 	{
 		spritenumber = 100;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	899
@@ -7227,11 +7463,13 @@ frames
 	911
 	{
 		spritenumber = 112;
+		bright = true;
 	}
 
 	912
 	{
 		spritenumber = 113;
+		bright = true;
 	}
 
 	913
@@ -7257,41 +7495,48 @@ frames
 	917
 	{
 		spritenumber = 118;
+		bright = true;
 	}
 
 	918
 	{
 		spritenumber = 118;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	919
 	{
 		spritenumber = 118;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	920
 	{
 		spritenumber = 118;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	921
 	{
 		spritenumber = 119;
+		bright = true;
 	}
 
 	922
 	{
 		spritenumber = 119;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	923
 	{
 		spritenumber = 119;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	924
@@ -7308,139 +7553,163 @@ frames
 	926
 	{
 		spritenumber = 121;
+		bright = true;
 	}
 
 	927
 	{
 		spritenumber = 121;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	928
 	{
 		spritenumber = 121;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	929
 	{
 		spritenumber = 121;
 		spritesubnumber = 3;
+		bright = true;
 	}
 
 	930
 	{
 		spritenumber = 122;
+		bright = true;
 	}
 
 	931
 	{
 		spritenumber = 122;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	932
 	{
 		spritenumber = 122;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	933
 	{
 		spritenumber = 122;
 		spritesubnumber = 3;
+		bright = true;
 	}
 
 	934
 	{
 		spritenumber = 123;
+		bright = true;
 	}
 
 	935
 	{
 		spritenumber = 123;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	936
 	{
 		spritenumber = 123;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	937
 	{
 		spritenumber = 123;
 		spritesubnumber = 3;
+		bright = true;
 	}
 
 	938
 	{
 		spritenumber = 124;
+		bright = true;
 	}
 
 	939
 	{
 		spritenumber = 124;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	940
 	{
 		spritenumber = 124;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	941
 	{
 		spritenumber = 124;
 		spritesubnumber = 3;
+		bright = true;
 	}
 
 	942
 	{
 		spritenumber = 125;
+		bright = true;
 	}
 
 	943
 	{
 		spritenumber = 125;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	944
 	{
 		spritenumber = 125;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	945
 	{
 		spritenumber = 125;
 		spritesubnumber = 3;
+		bright = true;
 	}
 
 	946
 	{
 		spritenumber = 126;
+		bright = true;
 	}
 
 	947
 	{
 		spritenumber = 126;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	948
 	{
 		spritenumber = 126;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	949
 	{
 		spritenumber = 126;
 		spritesubnumber = 3;
+		bright = true;
 	}
 
 	950
@@ -7491,71 +7760,83 @@ frames
 	959
 	{
 		spritenumber = 136;
+		bright = true;
 	}
 
 	960
 	{
 		spritenumber = 136;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	961
 	{
 		spritenumber = 136;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	962
 	{
 		spritenumber = 136;
 		spritesubnumber = 3;
+		bright = true;
 	}
 
 	963
 	{
 		spritenumber = 137;
+		bright = true;
 	}
 
 	964
 	{
 		spritenumber = 137;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	965
 	{
 		spritenumber = 137;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	966
 	{
 		spritenumber = 137;
 		spritesubnumber = 3;
+		bright = true;
 	}
 
 	968
 	{
 		spritenumber = 22;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	969
 	{
 		spritenumber = 22;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	970
 	{
 		spritenumber = 22;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	971
 	{
 		spritenumber = 22;
 		spritesubnumber = 3;
+		bright = true;
 	}
 
 	972
@@ -7977,71 +8258,83 @@ frames
 	1042
 	{
 		spritenumber = 140;
+		bright = true;
 	}
 
 	1043
 	{
 		spritenumber = 140;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	1044
 	{
 		spritenumber = 140;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	1045
 	{
 		spritenumber = 140;
 		spritesubnumber = 3;
+		bright = true;
 	}
 
 	1046
 	{
 		spritenumber = 140;
 		spritesubnumber = 4;
+		bright = true;
 	}
 
 	1047
 	{
 		spritenumber = 140;
 		spritesubnumber = 5;
+		bright = true;
 	}
 
 	1048
 	{
 		spritenumber = 140;
 		spritesubnumber = 6;
+		bright = true;
 	}
 
 	1049
 	{
 		spritenumber = 141;
+		bright = true;
 	}
 
 	1050
 	{
 		spritenumber = 141;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	1051
 	{
 		spritenumber = 141;
 		spritesubnumber = 2;
+		bright = true;
 	}
 
 	1052
 	{
 		spritenumber = 141;
 		spritesubnumber = 3;
+		bright = true;
 	}
 
 	1053
 	{
 		spritenumber = 141;
 		spritesubnumber = 4;
+		bright = true;
 	}
 
 	1054
@@ -8170,6 +8463,7 @@ frames
 	{
 		spritenumber = 22;
 		spritesubnumber = 1;
+		bright = true;
 	}
 
 	1076
@@ -8227,6 +8521,7 @@ frames
 	1085
 	{
 		spritenumber = 17;
+		bright = true;
 	}
 
 	1086
@@ -8248,7 +8543,6 @@ frames
 	}
 
 }
-
 
 sprites
 {
@@ -8499,3 +8793,38 @@ sprites
 	244 = "SP99";
 }
 
+bitmnemonics
+{
+	1 = "special";
+	2 = "solid";
+	4 = "shootable";
+	8 = "nosector";
+	16 = "noblockmap";
+	32 = "ambush";
+	64 = "justhit";
+	128 = "justattacked";
+	256 = "spawnceiling";
+	512 = "nogravity";
+	1024 = "dropoff";
+	2048 = "pickup";
+	4096 = "noclip";
+	8192 = "slide";
+	16384 = "float";
+	32768 = "teleport";
+	65536 = "missile";
+	131072 = "dropped";
+	262144 = "shadow";
+	524288 = "noblood";
+	1048576 = "corpse";
+	2097152 = "infloat";
+	4194304 = "countkill";
+	8388608 = "countitem";
+	16777216 = "skullfly";
+	33554432 = "notdmatch";
+	67108864 = "translation";
+	134217728 = "unused1";
+	268435456 = "unused2";
+	536870912 = "unused3";
+	1073741824 = "unused4";
+	2147483648 = "translucent";
+}

--- a/Build/Configurations/MBF21_Doom2Doom.cfg
+++ b/Build/Configurations/MBF21_Doom2Doom.cfg
@@ -65,3 +65,8 @@ enums
   // Basic game enums
   include("Includes\\Doom_misc.cfg", "enums");
 }
+
+dehacked
+{
+  include("Includes\\Dehacked_Doom.cfg");
+}

--- a/Build/Configurations/MBF21_Doom2Doom.cfg
+++ b/Build/Configurations/MBF21_Doom2Doom.cfg
@@ -66,6 +66,7 @@ enums
   include("Includes\\Doom_misc.cfg", "enums");
 }
 
+// Dehacked data
 dehacked
 {
   include("Includes\\Dehacked_Doom.cfg");

--- a/Build/Configurations/ZDoom_DoomDoom.cfg
+++ b/Build/Configurations/ZDoom_DoomDoom.cfg
@@ -62,3 +62,9 @@ enums
 	// Additional ZDoom enums for that game
 	include("Includes\\ZDoom_misc.cfg", "enums_doom");
 }
+
+// Dehacked data
+dehacked
+{
+  include("Includes\\Dehacked_Doom.cfg");
+}

--- a/Build/Configurations/ZDoom_DoomHexen.cfg
+++ b/Build/Configurations/ZDoom_DoomHexen.cfg
@@ -62,3 +62,9 @@ enums
 	// Additional ZDoom enums for that game
 	include("Includes\\ZDoom_misc.cfg", "enums_doom");
 }
+
+// Dehacked data
+dehacked
+{
+  include("Includes\\Dehacked_Doom.cfg");
+}

--- a/Build/Configurations/ZDoom_DoomUDMF.cfg
+++ b/Build/Configurations/ZDoom_DoomUDMF.cfg
@@ -62,3 +62,9 @@ enums
 	// Additional ZDoom enums for that game
 	include("Includes\\ZDoom_misc.cfg", "enums_doom");
 }
+
+// Dehacked data
+dehacked
+{
+  include("Includes\\Dehacked_Doom.cfg");
+}

--- a/Build/Configurations/Zandronum_DoomDoom.cfg
+++ b/Build/Configurations/Zandronum_DoomDoom.cfg
@@ -67,3 +67,9 @@ enums
 	// Additional enums from the engine
 	include("Includes\\Zandronum_misc.cfg", "enums_doom");
 }
+
+// Dehacked data
+dehacked
+{
+  include("Includes\\Dehacked_Doom.cfg");
+}

--- a/Build/Configurations/Zandronum_DoomHexen.cfg
+++ b/Build/Configurations/Zandronum_DoomHexen.cfg
@@ -74,3 +74,9 @@ enums
 	// Additional enums from the engine
 	include("Includes\\Zandronum_misc.cfg", "enums_doom");
 }
+
+// Dehacked data
+dehacked
+{
+  include("Includes\\Dehacked_Doom.cfg");
+}

--- a/Build/Configurations/Zandronum_DoomUDMF.cfg
+++ b/Build/Configurations/Zandronum_DoomUDMF.cfg
@@ -79,3 +79,9 @@ enums
 	// Additional enums from the engine
 	include("Includes\\Zandronum_misc.cfg", "enums_doom");
 }
+
+// Dehacked data
+dehacked
+{
+  include("Includes\\Dehacked_Doom.cfg");
+}

--- a/Source/Core/Builder.csproj
+++ b/Source/Core/Builder.csproj
@@ -204,6 +204,10 @@
     <Compile Include="Data\FlatImage.cs" />
     <Compile Include="Data\ImageLoadState.cs" />
     <Compile Include="Data\Scripting\ZScriptScriptHandler.cs" />
+    <Compile Include="Dehacked\DehackedData.cs" />
+    <Compile Include="Dehacked\DehackedFrame.cs" />
+    <Compile Include="Dehacked\DehackedParser.cs" />
+    <Compile Include="Dehacked\DehackedThing.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/Source/Core/BuilderMono.csproj
+++ b/Source/Core/BuilderMono.csproj
@@ -938,6 +938,10 @@
     <Compile Include="Data\PK3StructuredReader.cs" />
     <Compile Include="Data\DynamicBitmapImage.cs" />
     <Compile Include="Data\VoxelImage.cs" />
+    <Compile Include="Dehacked\DehackedData.cs" />
+    <Compile Include="Dehacked\DehackedFrame.cs" />
+    <Compile Include="Dehacked\DehackedParser.cs" />
+    <Compile Include="Dehacked\DehackedThing.cs" />	
     <Compile Include="Editing\CustomThingsFilter.cs" />
     <Compile Include="General\CRC.cs" />
     <Compile Include="General\ErrorItem.cs" />

--- a/Source/Core/Config/GameConfiguration.cs
+++ b/Source/Core/Config/GameConfiguration.cs
@@ -24,6 +24,7 @@ using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using CodeImp.DoomBuilder.Dehacked;
 using CodeImp.DoomBuilder.IO;
 using CodeImp.DoomBuilder.Map;
 using CodeImp.DoomBuilder.Editing;
@@ -204,6 +205,9 @@ namespace CodeImp.DoomBuilder.Config
 		// Compatibility options
 		CompatibilityOptions compatibility;
 
+		// Dehacked
+		private DehackedData dehackeddata;
+
         #endregion
 
         #region ================== Properties
@@ -352,6 +356,9 @@ namespace CodeImp.DoomBuilder.Config
 
 		// Compatibility options
 		public CompatibilityOptions Compatibility { get { return compatibility; } }
+
+		// Dehacked
+		public DehackedData DehackedData { get { return dehackeddata; } }
 		
 		#endregion
 
@@ -556,6 +563,9 @@ namespace CodeImp.DoomBuilder.Config
 
 			// Compatibility options
 			compatibility = new CompatibilityOptions(cfg);
+
+			// Dehacked
+			dehackeddata = new DehackedData(cfg, "dehacked");
 		}
 
 		// Destructor

--- a/Source/Core/Config/ScriptConfiguration.cs
+++ b/Source/Core/Config/ScriptConfiguration.cs
@@ -54,6 +54,7 @@ namespace CodeImp.DoomBuilder.Config
 		FONTDEFS,
         ZSCRIPT,
 		DECALDEF,
+		DEHACKED,
 	}
 	
 	internal class ScriptConfiguration : IComparable<ScriptConfiguration>

--- a/Source/Core/Config/ThingTypeInfo.cs
+++ b/Source/Core/Config/ThingTypeInfo.cs
@@ -481,6 +481,9 @@ namespace CodeImp.DoomBuilder.Config
 
 		internal ThingTypeInfo(ThingCategory cat, DehackedThing thing) : this(cat, thing.DoomEdNum, thing.Name)
 		{
+			category = cat;
+			bright = thing.Bright;
+
 			ModifyByDehackedThing(thing);
 		}
 
@@ -630,21 +633,37 @@ namespace CodeImp.DoomBuilder.Config
             dynamiclighttype = GZGeneral.GetGZLightTypeByClass(actor);
         }
 
+		/// <summary>
+		/// Modifies the thing type info by the given Dehacked thing.
+		/// </summary>
+		/// <param name="thing">The Dehacked thing to modify the thing type info by</param>
 		internal void ModifyByDehackedThing(DehackedThing thing)
 		{
-			sprite = thing.Sprite;
+			if(string.IsNullOrEmpty(thing.Sprite))
+				sprite = DataManager.INTERNAL_PREFIX + "unknownthing";
+			else
+				sprite = thing.Sprite;
 
 			title = thing.Name;
 			if (thing.Height != 0) height = thing.Height;
 			if (thing.Width != 0) radius = thing.Width;
 			blocking = thing.Bits.Contains("solid") ? 1 : 0;
 			hangs = thing.Bits.Contains("spawnceiling");
-		
+
+			if (thing.Color >= 0 && thing.Color <= 19)
+				color = thing.Color;
+
 			spriteframe = new[] { new SpriteFrameInfo { Sprite = sprite, SpriteLongName = Lump.MakeLongName(sprite, true) } };
 		}
 
+		/// <summary>
+		/// Changes the sprite of the thing by Dehacked sprite replacements.
+		/// </summary>
+		/// <param name="texts">Dehacked sprite replacements</param>
 		internal void ModifyBySpriteReplacement(Dictionary<string, string> texts)
 		{
+			// Cut the sprite into the 4 character base sprite and the animation, then rebuild 
+			// the sprite with the sprite replacement if necessary...
 			if (sprite.Length >= 4)
 			{
 				string basesprite = sprite.Substring(0, 4);
@@ -656,7 +675,8 @@ namespace CodeImp.DoomBuilder.Config
 				}
 			}
 
-			for (int i =0; i < spriteframe.Length; i++)
+			// ... then do the same with every sprite frame
+			for (int i=0; i < spriteframe.Length; i++)
 			{
 				SpriteFrameInfo sfi = spriteframe[i];
 

--- a/Source/Core/Config/ThingTypeInfo.cs
+++ b/Source/Core/Config/ThingTypeInfo.cs
@@ -22,7 +22,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Globalization;
 using CodeImp.DoomBuilder.Data;
-using CodeImp.DoomBuilder.GZBuilder.Data;
+using CodeImp.DoomBuilder.Dehacked;
 using CodeImp.DoomBuilder.IO;
 using CodeImp.DoomBuilder.Map;
 using CodeImp.DoomBuilder.Rendering;
@@ -479,6 +479,11 @@ namespace CodeImp.DoomBuilder.Config
             GC.SuppressFinalize(this);
 		}
 
+		internal ThingTypeInfo(ThingCategory cat, DehackedThing thing) : this(cat, thing.DoomEdNum, thing.Name)
+		{
+			ModifyByDehackedThing(thing);
+		}
+
 		#endregion
 
 		#region ================== Methods
@@ -624,6 +629,50 @@ namespace CodeImp.DoomBuilder.Config
             // [ZZ]
             dynamiclighttype = GZGeneral.GetGZLightTypeByClass(actor);
         }
+
+		internal void ModifyByDehackedThing(DehackedThing thing)
+		{
+			sprite = thing.Sprite;
+
+			title = thing.Name;
+			if (thing.Height != 0) height = thing.Height;
+			if (thing.Width != 0) radius = thing.Width;
+			blocking = thing.Bits.Contains("solid") ? 1 : 0;
+			hangs = thing.Bits.Contains("spawnceiling");
+		
+			spriteframe = new[] { new SpriteFrameInfo { Sprite = sprite, SpriteLongName = Lump.MakeLongName(sprite, true) } };
+		}
+
+		internal void ModifyBySpriteReplacement(Dictionary<string, string> texts)
+		{
+			if (sprite.Length >= 4)
+			{
+				string basesprite = sprite.Substring(0, 4);
+				string animation = sprite.Substring(4);
+
+				if (texts.ContainsKey(basesprite))
+				{
+					sprite = texts[basesprite] + animation;
+				}
+			}
+
+			for (int i =0; i < spriteframe.Length; i++)
+			{
+				SpriteFrameInfo sfi = spriteframe[i];
+
+				if (sfi.Sprite.Length < 4)
+					continue;
+
+				string basesprite = sfi.Sprite.Substring(0, 4);
+				string animation = sfi.Sprite.Substring(4);
+
+				if (texts.ContainsKey(basesprite))
+				{
+					string newsprite = texts[basesprite] + animation;
+					spriteframe[i] = new SpriteFrameInfo { Sprite = newsprite, SpriteLongName = Lump.MakeLongName(newsprite, true) };
+				}
+			}
+		}
 
         //mxd. This tries to find all possible sprite rotations. Returns true when voxel substitute exists
         internal bool SetupSpriteFrame(HashSet<string> allspritenames, HashSet<string> allvoxelnames)

--- a/Source/Core/Data/DataManager.cs
+++ b/Source/Core/Data/DataManager.cs
@@ -2056,6 +2056,9 @@ namespace CodeImp.DoomBuilder.Data
 		/// </summary>
 		private void FixRenamedDehackedSprites()
 		{
+			if (dehacked.Things.Count == 0)
+				return;
+
 			foreach(ThingTypeInfo tti in thingtypes.Values)
 			{
 				tti.ModifyBySpriteReplacement(dehacked.GetSpriteReplacements());

--- a/Source/Core/Data/DataReader.cs
+++ b/Source/Core/Data/DataReader.cs
@@ -222,10 +222,13 @@ namespace CodeImp.DoomBuilder.Data
 
 		//mxd. When implemented, returns all sprites, which name starts with given string
 		public abstract HashSet<string> GetSpriteNames();
-		
+
 		#endregion
 
 		#region ================== Decorate, Modeldef, Mapinfo, Gldefs, etc...
+
+		// When implemented, this returns DEHACKED lumps
+		public abstract IEnumerable<TextResourceData> GetDehackedData(string pname);
 
 		// When implemented, this returns DECORATE lumps
 		public abstract IEnumerable<TextResourceData> GetDecorateData(string pname);

--- a/Source/Core/Data/PK3StructuredReader.cs
+++ b/Source/Core/Data/PK3StructuredReader.cs
@@ -484,6 +484,33 @@ namespace CodeImp.DoomBuilder.Data
 
 		#endregion
 
+		#region ================== DEHACKED
+
+		// This finds and returns DEHACKED streams
+		public override IEnumerable<TextResourceData> GetDehackedData(string pname)
+		{
+			// Error when suspended
+			if (issuspended) throw new Exception("Data reader is suspended");
+
+			List<TextResourceData> result = new List<TextResourceData>();
+			string[] allfilenames;
+
+			// Find in root directory
+			string filename = Path.GetFileName(pname);
+			string pathname = Path.GetDirectoryName(pname);
+
+			if (filename.IndexOf('.') > -1)
+			{
+				allfilenames = GetFileAtPath(filename, pathname, "DEHACKED");
+			}
+			else
+				allfilenames = GetAllFilesWithTitle(pathname, filename, false);
+
+			return result;
+		}
+
+		#endregion
+
 		#region ================== DECORATE
 
 		// This finds and returns DECORATE streams

--- a/Source/Core/Data/WADReader.cs
+++ b/Source/Core/Data/WADReader.cs
@@ -1011,6 +1011,12 @@ namespace CodeImp.DoomBuilder.Data
 
 		#region ================== Decorate, Gldefs, Mapinfo, etc...
 
+		public override IEnumerable<TextResourceData> GetDehackedData(string pname)
+		{
+			if (issuspended) throw new Exception("Data reader is suspended");
+			return GetLastLumpData(pname);
+		}
+
 		// This finds and returns DECORATE streams
 		public override IEnumerable<TextResourceData> GetDecorateData(string pname)
 		{

--- a/Source/Core/Dehacked/DehackedData.cs
+++ b/Source/Core/Dehacked/DehackedData.cs
@@ -44,6 +44,7 @@ namespace CodeImp.DoomBuilder.Dehacked
 		private Dictionary<int, DehackedThing> things;
 		private Dictionary<int, DehackedFrame> frames;
 		private Dictionary<int, string> sprites;
+		private Dictionary<long, string> bitmnemonics;
 		private DehackedFrame defaultframe;
 		private Configuration cfg;
 		private string root;
@@ -55,6 +56,7 @@ namespace CodeImp.DoomBuilder.Dehacked
 		public Dictionary<int, DehackedThing> Things { get { return things; } }
 		public Dictionary<int, DehackedFrame> Frames { get { return frames; } }
 		public Dictionary<int, string> Sprites { get { return sprites; } }
+		public Dictionary<long, string> BitMnemonics { get { return bitmnemonics; } }
 
 		#endregion
 
@@ -65,6 +67,7 @@ namespace CodeImp.DoomBuilder.Dehacked
 			things = new Dictionary<int, DehackedThing>();
 			frames = new Dictionary<int, DehackedFrame>();
 			sprites = new Dictionary<int, string>();
+			bitmnemonics = new Dictionary<long, string>();
 
 			this.cfg = cfg;
 			this.root = root;
@@ -95,6 +98,15 @@ namespace CodeImp.DoomBuilder.Dehacked
 
 				if (int.TryParse(sb.Key.ToString(), out key))
 					sprites[key] = cfg.ReadSetting(root + ".sprites." + key, "----");
+			}
+
+			IDictionary bitmnemonicsblock = cfg.ReadSetting(root + ".bitmnemonics", new Hashtable());
+			foreach (DictionaryEntry bmb in bitmnemonicsblock)
+			{
+				int key;
+
+				if (int.TryParse(bmb.Key.ToString(), out key))
+					bitmnemonics[key] = cfg.ReadSetting(root + ".bitmnemonics." + key, "unset");
 			}
 		}
 

--- a/Source/Core/Dehacked/DehackedData.cs
+++ b/Source/Core/Dehacked/DehackedData.cs
@@ -1,0 +1,150 @@
+﻿#region ================== Copyright (c) 2021 Boris Iwanski
+
+/*
+ * This program is free software: you can redistribute it and/or modify
+ *
+ * it under the terms of the GNU General Public License as published by
+ * 
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * 
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.If not, see<http://www.gnu.org/licenses/>.
+ */
+
+#endregion
+
+#region ================== Namespaces
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CodeImp.DoomBuilder.Config;
+using CodeImp.DoomBuilder.IO;
+
+#endregion
+
+
+namespace CodeImp.DoomBuilder.Dehacked
+{
+	public class DehackedData
+	{
+		#region ================== Variables
+
+		private Dictionary<int, DehackedThing> things;
+		private Dictionary<int, DehackedFrame> frames;
+		private Dictionary<int, string> sprites;
+		private DehackedFrame defaultframe;
+		private Configuration cfg;
+		private string root;
+
+		#endregion
+
+		#region ================== Properties
+
+		public Dictionary<int, DehackedThing> Things { get { return things; } }
+		public Dictionary<int, DehackedFrame> Frames { get { return frames; } }
+		public Dictionary<int, string> Sprites { get { return sprites; } }
+
+		#endregion
+
+		#region ================== Constructor
+
+		internal DehackedData(Configuration cfg, string root)
+		{
+			things = new Dictionary<int, DehackedThing>();
+			frames = new Dictionary<int, DehackedFrame>();
+			sprites = new Dictionary<int, string>();
+
+			this.cfg = cfg;
+			this.root = root;
+
+			IDictionary thingblocks = cfg.ReadSetting(root + ".things", new Hashtable());
+			foreach(DictionaryEntry tb in thingblocks)
+			{
+				int dehackedid = int.Parse(tb.Key.ToString());
+				things[dehackedid] = LoadThing(tb);
+			}
+
+			IDictionary frameblocks = cfg.ReadSetting(root + ".frames", new Hashtable());
+			foreach (DictionaryEntry fb in frameblocks)
+			{
+				if (fb.Key.ToString() == "default")
+					defaultframe = LoadFrame(fb);
+				else
+				{
+					int frameindex = int.Parse(fb.Key.ToString());
+					frames[frameindex] = LoadFrame(fb);
+				}
+			}
+
+			IDictionary spriteblock = cfg.ReadSetting(root + ".sprites", new Hashtable());
+			foreach (DictionaryEntry sb in spriteblock)
+			{
+				int key;
+
+				if (int.TryParse(sb.Key.ToString(), out key))
+					sprites[key] = cfg.ReadSetting(root + ".sprites." + key, "----");
+			}
+		}
+
+		#endregion
+
+		#region ================== Methods
+
+		private DehackedThing LoadThing(DictionaryEntry entry)
+		{
+			int dehackedid = int.Parse(entry.Key.ToString());
+			string path = string.Format("{0}.things.{1}.", root, dehackedid);
+			string name = cfg.ReadSetting(path + "name", "<No name>");
+			int doomednum = cfg.ReadSetting(path + "doomednum", -1);
+			int height = cfg.ReadSetting(path + "height", 0);
+			int width = cfg.ReadSetting(path + "width", 0);
+			int initialframe = cfg.ReadSetting(path + "initialframe", 0);
+			long bits = cfg.ReadSetting(path + "bits", 0L);
+
+			Dictionary<string, string> props = new Dictionary<string, string>
+			{
+				{ "id #", doomednum.ToString() },
+				{ "initial frame", initialframe.ToString() },
+				{ "width", width.ToString() },
+				{ "height", height.ToString() },
+				{ "bits", bits.ToString() }
+			};
+
+			return new DehackedThing(dehackedid, name, props);
+		}
+
+		private DehackedFrame LoadFrame(DictionaryEntry entry)
+		{
+			int frameid;
+			int.TryParse(entry.Key.ToString(), out frameid);
+			string path = string.Format("{0}.frames.{1}.", root, entry.Key.ToString());
+			int spritenumber = cfg.ReadSetting(path + "spritenumber", 0);
+			long spritesubnumber = cfg.ReadSetting(path + "spritesubnumber", 0L);
+
+			if (spritesubnumber >= 32768)
+				spritesubnumber -= 32768;
+
+			Dictionary<string, string> props = new Dictionary<string, string>
+			{
+				{ "sprite number", spritenumber.ToString() },
+				{ "sprite subnumber", spritesubnumber.ToString() }
+			};
+
+			return new DehackedFrame(frameid, props);
+		}
+
+		#endregion
+	}
+}

--- a/Source/Core/Dehacked/DehackedFrame.cs
+++ b/Source/Core/Dehacked/DehackedFrame.cs
@@ -42,6 +42,7 @@ namespace CodeImp.DoomBuilder.Dehacked
 		private long spritesubnumber;
 		private Dictionary<string, string> props;
 		private string sprite;
+		private bool bright;
 
 		#endregion
 
@@ -52,6 +53,7 @@ namespace CodeImp.DoomBuilder.Dehacked
 		public long SpriteSubNumber { get { return spritesubnumber; } internal set { spritesubnumber = value; } }
 		public Dictionary<string, string> Props { get { return props; } }
 		public string Sprite { get { return sprite; } internal set { sprite = value; } }
+		public bool Bright { get { return bright; } }
 
 		#endregion
 
@@ -74,8 +76,14 @@ namespace CodeImp.DoomBuilder.Dehacked
 
 		#region ================== Methods
 
+		/// <summary>
+		/// Processes the frame, setting it up so it can be used by things
+		/// </summary>
+		/// <param name="definedsprites">All available Dehacked sprites</param>
+		/// <param name="baseframe">The base Dehacked frame</param>
 		internal void Process(Dictionary<int, string> definedsprites, DehackedFrame baseframe)
 		{
+			// Copy all missing properties of the base frame
 			if(baseframe != null)
 			{
 				foreach (string key in baseframe.Props.Keys)
@@ -94,11 +102,16 @@ namespace CodeImp.DoomBuilder.Dehacked
 						spritenumber = int.Parse(value);
 						if (definedsprites.ContainsKey(spritenumber))
 							sprite = definedsprites[spritenumber];
+						else
+							General.ErrorLogger.Add(ErrorType.Error, "Dehacked frame " + number + " is referencing sprite " + spritenumber + " that is not defined.");
 						break;
 					case "sprite subnumber":
 						spritesubnumber = long.Parse(value);
 						if (spritesubnumber >= 32768)
+						{
 							spritesubnumber -= 32768;
+							bright = true;
+						}
 						break;
 				}
 			}

--- a/Source/Core/Dehacked/DehackedFrame.cs
+++ b/Source/Core/Dehacked/DehackedFrame.cs
@@ -1,0 +1,109 @@
+﻿#region ================== Copyright (c) 2021 Boris Iwanski
+
+/*
+ * This program is free software: you can redistribute it and/or modify
+ *
+ * it under the terms of the GNU General Public License as published by
+ * 
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * 
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.If not, see<http://www.gnu.org/licenses/>.
+ */
+
+#endregion
+
+#region ================== Namespaces
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+#endregion
+
+namespace CodeImp.DoomBuilder.Dehacked
+{
+	public class DehackedFrame
+	{
+		#region ================== Variables
+
+		private int number;
+		private int spritenumber;
+		private long spritesubnumber;
+		private Dictionary<string, string> props;
+		private string sprite;
+
+		#endregion
+
+		#region ================== Properties
+
+		public int Number { get { return number; } internal set { number = value; } }
+		public int SpriteNumber { get { return spritenumber; } internal set { spritenumber = value; } }
+		public long SpriteSubNumber { get { return spritesubnumber; } internal set { spritesubnumber = value; } }
+		public Dictionary<string, string> Props { get { return props; } }
+		public string Sprite { get { return sprite; } internal set { sprite = value; } }
+
+		#endregion
+
+		#region ================== Constructor
+
+		internal DehackedFrame(int number)
+		{
+			this.number = number;
+			sprite = string.Empty;
+			props = new Dictionary<string, string>();
+		}
+
+		internal DehackedFrame(int number, Dictionary<string, string> props) : this(number)
+		{
+			foreach (string key in props.Keys)
+				this.props[key.ToLowerInvariant()] = props[key];
+		}
+
+		#endregion
+
+		#region ================== Methods
+
+		internal void Process(Dictionary<int, string> definedsprites, DehackedFrame baseframe)
+		{
+			if(baseframe != null)
+			{
+				foreach (string key in baseframe.Props.Keys)
+					if (!props.ContainsKey(key))
+						props[key] = baseframe.props[key];
+			}
+
+			foreach (KeyValuePair<string, string> kvp in props)
+			{
+				string prop = kvp.Key.ToLowerInvariant();
+				string value = kvp.Value;
+
+				switch (prop)
+				{
+					case "sprite number":
+						spritenumber = int.Parse(value);
+						if (definedsprites.ContainsKey(spritenumber))
+							sprite = definedsprites[spritenumber];
+						break;
+					case "sprite subnumber":
+						spritesubnumber = long.Parse(value);
+						if (spritesubnumber >= 32768)
+							spritesubnumber -= 32768;
+						break;
+				}
+			}
+		}
+
+		#endregion
+	}
+}

--- a/Source/Core/Dehacked/DehackedParser.cs
+++ b/Source/Core/Dehacked/DehackedParser.cs
@@ -1,0 +1,389 @@
+﻿#region ================== Copyright (c) 2021 Boris Iwanski
+
+/*
+ * This program is free software: you can redistribute it and/or modify
+ *
+ * it under the terms of the GNU General Public License as published by
+ * 
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * 
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.If not, see<http://www.gnu.org/licenses/>.
+ */
+
+#endregion
+
+#region ================== Namespaces
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using CodeImp.DoomBuilder.Config;
+using CodeImp.DoomBuilder.Data;
+
+#endregion
+
+namespace CodeImp.DoomBuilder.Dehacked
+{
+	internal sealed class DehackedParser
+	{
+		#region ================== Variables
+
+		private StreamReader datareader;
+		private List<DehackedThing> things;
+		private string sourcename;
+		private DataLocation datalocation;
+		private int sourcelumpindex;
+		private int linenumber;
+		private Dictionary<int, DehackedFrame> frames;
+		private Dictionary<string, string> texts;
+		private Dictionary<int, string> sprites;
+
+		private Dictionary<long, string> bitmnemonics = new Dictionary<long, string>()
+		{
+			{ 0x00000001, "special" },
+			{ 0x00000002, "solid" },
+			{ 0x00000004, "shootable" },
+			{ 0x00000008, "nosector" },
+			{ 0x00000010, "noblockmap" },
+			{ 0x00000020, "ambush" },
+			{ 0x00000040, "justhit" },
+			{ 0x00000080, "justattacked" },
+			{ 0x00000100, "spawnceiling" },
+			{ 0x00000200, "nogravity" },
+			{ 0x00000400, "dropoff" },
+			{ 0x00000800, "pickup" },
+			{ 0x00001000, "noclip" },
+			{ 0x00002000, "slide" },
+			{ 0x00004000, "float" },
+			{ 0x00008000, "teleport" },
+			{ 0x00010000, "missile" },
+			{ 0x00020000, "dropped" },
+			{ 0x00040000, "shadow" },
+			{ 0x00080000, "noblood" },
+			{ 0x00100000, "corpse" },
+			{ 0x00200000, "infloat" },
+			{ 0x00400000, "countkill" },
+			{ 0x00800000, "countitem" },
+			{ 0x01000000, "skullfly" },
+			{ 0x02000000, "notdmatch" },
+			{ 0x04000000, "translation" },
+			{ 0x08000000, "unused1" },
+			{ 0x10000000, "unused2" },
+			{ 0x20000000, "unused3" },
+			{ 0x40000000, "unused4" },
+			{ 0x80000000, "translucent" },
+		};
+
+		#endregion
+
+		#region ================== Enumerations
+
+		private enum ParseSection
+		{
+			HEADER,
+			THING,
+			FRAME,
+			WEAPON,
+			CODEPTR,
+			STRINGS,
+			SPRITES,
+			SOUNDS,
+			TEXT
+		}
+
+		#endregion
+
+		#region ================== Properties
+
+		public List<DehackedThing> Things { get { return things; } }
+		public Dictionary<string, string> Texts { get { return texts; } }
+
+		#endregion
+
+		#region ================== Constructor
+
+		public DehackedParser()
+		{
+			things = new List<DehackedThing>();
+			frames = new Dictionary<int, DehackedFrame>();
+			texts = new Dictionary<string, string>();
+			sprites = new Dictionary<int, string>();
+		}
+
+		#endregion
+
+		#region ================== Parsing
+
+		public bool Parse(TextResourceData data, DehackedData dehackeddata, HashSet<string> availablesprites)
+		{
+			ParseSection parsesection = ParseSection.HEADER;
+			string line;
+			string fieldkey = string.Empty;
+			string fieldvalue = string.Empty;
+			bool hasfieldvaluepair = false;
+			int textreplaceoldcount = 0;
+			int textreplacenewcount = 0;
+			DehackedThing thing = null;
+			DehackedFrame frame = null;
+
+			sourcename = data.Filename;
+			datalocation = data.SourceLocation;
+			sourcelumpindex = data.LumpIndex;
+
+			using (datareader = new StreamReader(data.Stream, Encoding.ASCII))
+			{
+				// Read header
+				line = GetLine();
+				if(line != "Patch File for DeHackEd v3.0")
+				{
+					LogError("Did not find expected Dehacked file header.");
+					return false;
+				}
+
+				while (!datareader.EndOfStream)
+				{
+					line = GetLine();
+
+					// Skip blank lines
+					if (string.IsNullOrEmpty(line))
+						continue;
+					// Comment lines start with #. Apparently comments after payload are not supported
+					else if (line.StartsWith("#"))
+						continue;
+					// field = values pairs
+					else if (line.Contains("="))
+					{
+						string[] parts = line.Split('=');
+						fieldkey = parts[0].Trim();
+						fieldvalue = parts[1].Trim();
+						hasfieldvaluepair = true;
+					}
+					else if (line.ToLowerInvariant().StartsWith("thing"))
+					{
+						Regex re = new Regex(@"thing\s+(\d+)\s+\((.+)\)", RegexOptions.IgnoreCase);
+						Match m = re.Match(line);
+
+						if (!m.Success)
+						{
+							LogError("Found thing definition, but thing header seems to be wrong.");
+							return false;
+						}
+
+						int dehthingnumber = int.Parse(m.Groups[1].Value);
+						string dehthingname = m.Groups[2].Value;
+
+						thing = new DehackedThing(dehthingnumber, dehthingname);
+						things.Add(thing);
+						parsesection = ParseSection.THING;
+
+						continue; // Go to next line
+					}
+					else if (line.ToLowerInvariant().StartsWith("frame") && parsesection != ParseSection.CODEPTR)
+					{
+						Regex re = new Regex(@"frame\s+(\d+)", RegexOptions.IgnoreCase);
+						Match m = re.Match(line);
+
+						if (!m.Success)
+						{
+							LogError("Found frame definition, but frame header seems to be wrong.");
+							return false;
+						}
+
+						int framenumber = int.Parse(m.Groups[1].Value);
+
+						frame = new DehackedFrame(framenumber);
+						frames[framenumber] = frame;
+
+						parsesection = ParseSection.FRAME;
+						continue; // Go to next line
+					}
+					else if (line.ToLowerInvariant().StartsWith("weapon"))
+					{
+						parsesection = ParseSection.WEAPON;
+						continue; // Go to next line
+					}
+					else if (line.ToLowerInvariant().StartsWith("[codeptr]"))
+					{
+						parsesection = ParseSection.CODEPTR;
+						continue; // Go to next line
+					}
+					else if (line.ToLowerInvariant().StartsWith("[strings]"))
+					{
+						parsesection = ParseSection.STRINGS;
+						continue; // Go to next line
+					}
+					else if(line.ToLowerInvariant().StartsWith("[sprites]"))
+					{
+						parsesection = ParseSection.SPRITES;
+						continue; // Go to next line
+					}
+					else if(line.ToLowerInvariant().StartsWith("[sounds]"))
+					{
+						parsesection = ParseSection.SOUNDS;
+						continue; // Go to next line
+					}
+					else if(line.ToLowerInvariant().StartsWith("text"))
+					{
+						parsesection = ParseSection.TEXT;
+
+						Regex re = new Regex(@"text\s+(\d+)\s+(\d+)", RegexOptions.IgnoreCase);
+						Match m = re.Match(line);
+
+						if (!m.Success)
+						{
+							LogError("Found text replacement definition, but text replacement header seems to be wrong.");
+							return false;
+						}
+
+						textreplaceoldcount = int.Parse(m.Groups[1].Value);
+						textreplacenewcount = int.Parse(m.Groups[2].Value);
+
+						StringBuilder oldtext = new StringBuilder(textreplaceoldcount);
+						while(textreplaceoldcount > 0)
+						{
+							int c = datareader.Read();
+
+							// Ignore CR
+							if (c == '\r') continue;
+
+							oldtext.Append(Convert.ToChar(c));
+							textreplaceoldcount--;
+						}
+
+						StringBuilder newtext = new StringBuilder();
+						while(textreplacenewcount > 0)
+						{
+							int c = datareader.Read();
+
+							// Ignore CR
+							if (c == '\r') continue;
+
+							newtext.Append(Convert.ToChar(c));
+							textreplacenewcount--;
+						}
+
+						if(datareader.Read() != '\r' && datareader.Read() != '\n')
+						{
+							LogError("Expected CRLF after text replacement, got something else.");
+							return false;
+						}
+
+						texts[oldtext.ToString()] = newtext.ToString();
+
+						continue;
+					}
+
+					switch (parsesection)
+					{
+						case ParseSection.HEADER:
+							if (hasfieldvaluepair)
+							{
+								if (fieldkey == "Doom version" && fieldvalue != "21")
+									LogWarning("Unexpected Doom version. Expected 21, got " + fieldvalue + ". Parsing might not work correctly.");
+								else if (fieldvalue == "Patch format" && fieldvalue != "6")
+									LogWarning("Unexpected patch format. Expected 6, got " + fieldvalue + ". Parsing might not work correctly.");
+							}
+							break;
+						case ParseSection.THING:
+							if(hasfieldvaluepair)
+							{
+								thing.Props[fieldkey.ToLowerInvariant()] = fieldvalue;
+							}
+							break;
+						case ParseSection.FRAME:
+							if(hasfieldvaluepair)
+							{
+								frame.Props[fieldkey.ToLowerInvariant()] = fieldvalue;
+							}
+							break;
+					}
+				}
+			}
+
+			// Process text replacements
+			foreach(int key in dehackeddata.Sprites.Keys)
+			{
+				string sprite = dehackeddata.Sprites[key];
+				if (texts.ContainsKey(sprite))
+					sprites[key] = texts[sprite];
+				else
+					sprites[key] = sprite;
+			}
+
+			// Process frames
+			foreach(int key in dehackeddata.Frames.Keys)
+			{
+				if (!frames.ContainsKey(key))
+					frames[key] = dehackeddata.Frames[key];
+			}
+
+			foreach(DehackedFrame f in frames.Values)
+				f.Process(sprites, dehackeddata.Frames.ContainsKey(f.Number) ? dehackeddata.Frames[f.Number] : null);
+
+			// Finalize things
+			foreach (DehackedThing t in things)
+				t.Process(frames, sprites, bitmnemonics, dehackeddata.Things.ContainsKey(t.Number) ? dehackeddata.Things[t.Number] : null, availablesprites);
+
+			return true;
+		}
+
+		/// <summary>
+		/// Returns a new line and increments the line number
+		/// </summary>
+		/// <returns>The read line</returns>
+		private string GetLine()
+		{
+			linenumber++;
+			return datareader.ReadLine().Trim();
+		}
+
+		/// <summary>
+		/// Logs a warning with the given message.
+		/// </summary>
+		/// <param name="message">The warning message</param>
+		private void LogWarning(string message)
+		{
+			string errsource = Path.Combine(datalocation.GetDisplayName(), sourcename);
+			if (sourcelumpindex != -1) errsource += ":" + sourcelumpindex;
+
+			message = "Dehacked warning in \"" + errsource + "\" line " + linenumber + ". " + message + ".";
+
+			TextResourceErrorItem error = new TextResourceErrorItem(ErrorType.Warning, ScriptType.DEHACKED, datalocation, sourcename, sourcelumpindex, linenumber, message);
+
+			General.ErrorLogger.Add(error);
+		}
+
+		/// <summary>
+		/// Logs an error with the given message.
+		/// </summary>
+		/// <param name="message">The error message</param>
+		private void LogError(string message)
+		{
+			string errsource = Path.Combine(datalocation.GetDisplayName(), sourcename);
+			if (sourcelumpindex != -1) errsource += ":" + sourcelumpindex;
+
+			message = "Dehacked error in \"" + errsource + "\" line " + linenumber + ". " + message + ".";
+
+			TextResourceErrorItem error = new TextResourceErrorItem(ErrorType.Error, ScriptType.DEHACKED, datalocation, sourcename, sourcelumpindex, linenumber, message);
+
+			General.ErrorLogger.Add(error);
+		}
+
+		#endregion
+
+
+	}
+}

--- a/Source/Core/Dehacked/DehackedThing.cs
+++ b/Source/Core/Dehacked/DehackedThing.cs
@@ -1,0 +1,154 @@
+﻿#region ================== Copyright (c) 2021 Boris Iwanski
+
+/*
+ * This program is free software: you can redistribute it and/or modify
+ *
+ * it under the terms of the GNU General Public License as published by
+ * 
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * 
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.If not, see<http://www.gnu.org/licenses/>.
+ */
+
+#endregion
+
+#region ================== Namespaces
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+#endregion
+
+namespace CodeImp.DoomBuilder.Dehacked
+{
+	public class DehackedThing
+	{
+		#region ================== Variables
+
+		private int number;
+		private string name;
+		private Dictionary<string, string> props;
+		private int doomednum;
+		private int initialframe;
+		private string sprite;
+		private int height;
+		private int width;
+		private List<string> bits;
+
+		#endregion
+
+		#region ================== Properties
+
+		public int Number { get { return number; } }
+		public Dictionary<string, string> Props { get { return props; } }
+		public int DoomEdNum { get { return doomednum; } internal set { doomednum = value; } }
+		public string Name { get { return name; } internal set { name = value; } }
+		public int InitialFrame { get { return initialframe; } internal set { initialframe = value; } }
+		public string Sprite { get { return sprite; } internal set { sprite = value; } }
+		public int Height { get { return height; } internal set { height = value; } }
+		public int Width { get { return width; } internal set { width = value; } }
+		public List<string> Bits { get { return bits; } }
+
+		#endregion
+
+		#region ================== Constructor
+
+		internal DehackedThing(int number, string name)
+		{
+			this.number = number;
+			this.name = name;
+
+			props = new Dictionary<string, string>();
+			bits = new List<string>();
+		}
+
+		internal DehackedThing(int number, string name, Dictionary<string, string> props) : this(number, name)
+		{
+			foreach(string key in props.Keys)
+			{
+				this.props[key.ToLowerInvariant()] = props[key];
+			}
+		}
+
+		#endregion
+
+		internal void Process(Dictionary<int, DehackedFrame> frames, Dictionary<int, string> definedsprites, Dictionary<long, string> bitmnemonics, DehackedThing basething, HashSet<string> availablesprites)
+		{
+			if(basething != null)
+			{
+				doomednum = basething.DoomEdNum;
+				foreach (string key in basething.Props.Keys)
+					if (!props.ContainsKey(key))
+						props[key] = basething.props[key];
+			}
+
+			foreach (KeyValuePair<string, string> kvp in props)
+			{
+				string prop = kvp.Key.ToLowerInvariant();
+				string value = kvp.Value;
+
+				switch (prop)
+				{
+					case "id #":
+						int.TryParse(value, out doomednum);
+						break;
+					case "initial frame":
+						if (int.TryParse(value, out initialframe))
+						{
+							if (frames.ContainsKey(initialframe))
+							{
+								// It doesn't seem to matter which rotation we select, UDB will automagically
+								// find the correct sprites later
+								string spritename = frames[initialframe].Sprite + Convert.ToChar(frames[initialframe].SpriteSubNumber + 'A');
+								if (availablesprites.Contains(spritename + "0"))
+									sprite = spritename + "0";
+								else
+									sprite = spritename + "1";
+							}
+						}
+						break;
+					case "width":
+						if(int.TryParse(value, out width))
+						{
+							// Value is in 16.16 fixed point, so shift it
+							width >>= 16;
+						}
+						break;
+					case "height":
+						if(int.TryParse(value, out height))
+						{
+							// Value is in 16.16 fixed point, so shift it
+							height >>= 16;
+						}
+						break;
+					case "bits":
+						long allbits;
+						if(long.TryParse(value, out allbits))
+						{
+							foreach (long mask in bitmnemonics.Keys)
+								if ((mask & allbits) == mask)
+									bits.Add(bitmnemonics[mask]);
+						}
+						else
+						{
+							foreach (string mnemonic in value.Split('+'))
+								bits.Add(mnemonic.Trim().ToLowerInvariant());
+						}
+						break;
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR adds DeHackEd support to UDB. The last `DEHACKED` lump in the resources is loaded, and thing defined in the patch are added to the thing types, or existing thing types are modified based on the patch.