### PR TITLE
UDBScript asynchronous execution

### DIFF
--- a/Source/Core/General/General.cs
+++ b/Source/Core/General/General.cs
@@ -144,6 +144,7 @@ namespace CodeImp.DoomBuilder
         internal const int WM_UIACTION = WM_USER + 1;
 		internal const int WM_SYSCOMMAND = 0x112;
         internal const int WM_MOUSEHWHEEL = 0x020E; // [ZZ]
+		internal const int WM_MOUSEWHEEL = 0x20A;
         internal const int SC_KEYMENU = 0xF100;
 		internal const int CB_SETITEMHEIGHT = 0x153;
 		//internal const int CB_SHOWDROPDOWN = 0x14F;

--- a/Source/Core/Map/MapSet.cs
+++ b/Source/Core/Map/MapSet.cs
@@ -1080,15 +1080,10 @@ namespace CodeImp.DoomBuilder.Map
 			Update(true, true);
 		}
 
-		public void Update(bool dolines, bool dosectors)
-		{
-			Update(dolines, dosectors, true);
-		}
-
 		/// <summary>
 		/// This updates the cache of all elements where needed. It is not recommended to use this version, please use Update() instead.
 		/// </summary>
-		public void Update(bool dolines, bool dosectors, bool allocatebuffers)
+		public void Update(bool dolines, bool dosectors)
 		{
 			// Update all linedefs
 			if(dolines) foreach(Linedef l in linedefs) l.UpdateCache();
@@ -1102,12 +1097,9 @@ namespace CodeImp.DoomBuilder.Map
 					s.UpdateBBox();
 				}
 
-				if (allocatebuffers)
-				{
-					General.Map.CRenderer2D.Surfaces.AllocateBuffers();
-					foreach (Sector s in sectors) s.CreateSurfaces();
-					General.Map.CRenderer2D.Surfaces.UnlockBuffers();
-				}
+				General.Map.CRenderer2D.Surfaces.AllocateBuffers();
+				foreach (Sector s in sectors) s.CreateSurfaces();
+				General.Map.CRenderer2D.Surfaces.UnlockBuffers();
 			}
 		}
 		

--- a/Source/Core/Windows/IMainForm.cs
+++ b/Source/Core/Windows/IMainForm.cs
@@ -42,6 +42,7 @@ namespace CodeImp.DoomBuilder.Windows
 		bool IsActiveWindow { get; }
 		string ActiveDockerTabName { get; } //mxd
 		RenderTargetControl Display { get; }
+		int ProcessingCount { get; }
 
 		//mxd. Events
 		event EventHandler OnEditFormValuesChanged;

--- a/Source/Core/Windows/MainForm.cs
+++ b/Source/Core/Windows/MainForm.cs
@@ -1352,22 +1352,26 @@ namespace CodeImp.DoomBuilder.Windows
 			if(alt) mod |= (int)Keys.Alt;
 			if(shift) mod |= (int)Keys.Shift;
 			if(ctrl) mod |= (int)Keys.Control;
-			
-			// Scrollwheel up?
-			if(e.Delta > 0)
+
+			// Only send key events when the main window can be focused (i.e. no modal dialogs are open)
+			if (CanFocus)
 			{
-				// Invoke actions for scrollwheel
-				//for(int i = 0; i < e.Delta; i += 120)
-				General.Actions.KeyPressed((int)SpecialKeys.MScrollUp | mod);
-				General.Actions.KeyReleased((int)SpecialKeys.MScrollUp | mod);
-			}
-			// Scrollwheel down?
-			else if(e.Delta < 0)
-			{
-				// Invoke actions for scrollwheel
-				//for(int i = 0; i > e.Delta; i -= 120)
-				General.Actions.KeyPressed((int)SpecialKeys.MScrollDown | mod);
-				General.Actions.KeyReleased((int)SpecialKeys.MScrollDown | mod);
+				// Scrollwheel up?
+				if (e.Delta > 0)
+				{
+					// Invoke actions for scrollwheel
+					//for(int i = 0; i < e.Delta; i += 120)
+					General.Actions.KeyPressed((int)SpecialKeys.MScrollUp | mod);
+					General.Actions.KeyReleased((int)SpecialKeys.MScrollUp | mod);
+				}
+				// Scrollwheel down?
+				else if (e.Delta < 0)
+				{
+					// Invoke actions for scrollwheel
+					//for(int i = 0; i > e.Delta; i -= 120)
+					General.Actions.KeyPressed((int)SpecialKeys.MScrollDown | mod);
+					General.Actions.KeyReleased((int)SpecialKeys.MScrollDown | mod);
+				}
 			}
 			
 			// Let the base know
@@ -4394,7 +4398,7 @@ namespace CodeImp.DoomBuilder.Windows
                     OnMouseHWheel(delta);
 					m.Result = new IntPtr(delta);
 					break;
-					
+
 				default:
 					// Let the base handle the message
 					base.WndProc(ref m);

--- a/Source/Core/Windows/MainForm.cs
+++ b/Source/Core/Windows/MainForm.cs
@@ -180,6 +180,7 @@ namespace CodeImp.DoomBuilder.Windows
 		public StatusInfo Status { get { return status; } }
 		public static Size ScaledIconSize = new Size(16, 16); //mxd
 		public static SizeF DPIScaler = new SizeF(1.0f, 1.0f); //mxd
+		public int ProcessingCount { get { return processingcount; } }
 		
 		#endregion
 

--- a/Source/Plugins/CommentsPanel/CommentsDocker.cs
+++ b/Source/Plugins/CommentsPanel/CommentsDocker.cs
@@ -159,7 +159,7 @@ namespace CodeImp.DoomBuilder.CommentsPanel
 		// This finds all comments and updates the list
 		public void UpdateList()
 		{
-			if(!preventupdate)
+			if(!preventupdate && General.Map.Map.IsSafeToAccess)
 			{
 				// Update vertices
 				Dictionary<string, CommentInfo> newcomments = new Dictionary<string, CommentInfo>(StringComparer.Ordinal);

--- a/Source/Plugins/UDBScript/API/MapWrapper.cs
+++ b/Source/Plugins/UDBScript/API/MapWrapper.cs
@@ -420,13 +420,11 @@ namespace CodeImp.DoomBuilder.UDBScript.Wrapper
 			// Snap to map format accuracy
 			General.Map.Map.SnapAllToAccuracy();
 
-			// Update map
-			//General.Map.Map.Update();
-			BuilderPlug.Me.ScriptRunnerForm.RunAction(() => General.Map.Map.Update(/*true, true, false*/));
+			// Update map. This has to run on the UI thread
+			BuilderPlug.Me.ScriptRunnerForm.RunAction(() => General.Map.Map.Update());
 
 			// Update textures
-			//BuilderPlug.Me.ScriptRunnerForm.RunAction(() => General.Map.Data.UpdateUsedTextures());
-
+			General.Map.Data.UpdateUsedTextures();
 
 			return success;
 		}
@@ -1184,7 +1182,7 @@ namespace CodeImp.DoomBuilder.UDBScript.Wrapper
 					sectors[i].Join(first);
 
 			// Update
-			General.Map.Map.Update();
+			BuilderPlug.Me.ScriptRunnerForm.RunAction(() => General.Map.Map.Update());
 		}
 
 		#endregion

--- a/Source/Plugins/UDBScript/API/MapWrapper.cs
+++ b/Source/Plugins/UDBScript/API/MapWrapper.cs
@@ -23,6 +23,7 @@
 
 #region ================== Namespaces
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using CodeImp.DoomBuilder.BuilderModes;
@@ -41,6 +42,7 @@ namespace CodeImp.DoomBuilder.UDBScript.Wrapper
 
 		private MapSet map;
 		private VisualCameraWrapper visualcamera;
+		private Vector2D mousemappos;
 
 		#endregion
 
@@ -86,10 +88,7 @@ namespace CodeImp.DoomBuilder.UDBScript.Wrapper
 		{
 			get
 			{
-				if (General.Editing.Mode is ClassicMode)
-					return ((ClassicMode)General.Editing.Mode).MouseMapPos;
-				else
-					return ((VisualMode)General.Editing.Mode).GetHitPosition();
+				return mousemappos;
 			}
 		}
 
@@ -112,6 +111,11 @@ namespace CodeImp.DoomBuilder.UDBScript.Wrapper
 		{
 			map = General.Map.Map;
 			visualcamera = new VisualCameraWrapper();
+
+			if (General.Editing.Mode is ClassicMode)
+				mousemappos = ((ClassicMode)General.Editing.Mode).MouseMapPos;
+			else
+				mousemappos = ((VisualMode)General.Editing.Mode).GetHitPosition();
 		}
 
 		#endregion
@@ -417,10 +421,12 @@ namespace CodeImp.DoomBuilder.UDBScript.Wrapper
 			General.Map.Map.SnapAllToAccuracy();
 
 			// Update map
-			General.Map.Map.Update();
+			//General.Map.Map.Update();
+			BuilderPlug.Me.ScriptRunnerForm.RunAction(() => General.Map.Map.Update(/*true, true, false*/));
 
 			// Update textures
-			General.Map.Data.UpdateUsedTextures();
+			//BuilderPlug.Me.ScriptRunnerForm.RunAction(() => General.Map.Data.UpdateUsedTextures());
+
 
 			return success;
 		}

--- a/Source/Plugins/UDBScript/BuilderPlug.cs
+++ b/Source/Plugins/UDBScript/BuilderPlug.cs
@@ -622,7 +622,6 @@ namespace CodeImp.DoomBuilder.UDBScript
 
 			scriptrunner = new ScriptRunner(currentscript);
 			scriptrunnerform.ShowDialog();
-			//scriptrunner.Run();
 		}
 
 		[BeginAction("udbscriptexecuteslot1")]
@@ -670,7 +669,7 @@ namespace CodeImp.DoomBuilder.UDBScript
 				if (scriptslots.ContainsKey(slot) && scriptslots[slot] != null)
 				{
 					scriptrunner = new ScriptRunner(scriptslots[slot]);
-					//scriptrunner.Run();
+					scriptrunnerform.ShowDialog();
 				}
 			}
 		}

--- a/Source/Plugins/UDBScript/BuilderPlug.cs
+++ b/Source/Plugins/UDBScript/BuilderPlug.cs
@@ -97,6 +97,7 @@ namespace CodeImp.DoomBuilder.UDBScript
 		private Dictionary<int, ScriptInfo> scriptslots;
 		private string editorexepath;
 		private PreferencesForm preferencesform;
+		private ScriptRunnerForm scriptrunnerform;
 
 		#endregion
 
@@ -108,6 +109,7 @@ namespace CodeImp.DoomBuilder.UDBScript
 		internal ScriptRunner ScriptRunner { get { return scriptrunner; } }
 		internal ScriptDirectoryStructure ScriptDirectoryStructure { get { return scriptdirectorystructure; } }
 		internal string EditorExePath { get { return editorexepath; } }
+		public ScriptRunnerForm ScriptRunnerForm { get { return scriptrunnerform; } }
 
 		#endregion
 
@@ -137,6 +139,8 @@ namespace CodeImp.DoomBuilder.UDBScript
 			watcher.Renamed += OnWatcherEvent;
 
 			editorexepath = General.Settings.ReadPluginSetting("externaleditor", string.Empty);
+
+			scriptrunnerform = new ScriptRunnerForm();
 
 			FindEditor();
 		}
@@ -617,7 +621,8 @@ namespace CodeImp.DoomBuilder.UDBScript
 				return;
 
 			scriptrunner = new ScriptRunner(currentscript);
-			scriptrunner.Run();
+			scriptrunnerform.ShowDialog();
+			//scriptrunner.Run();
 		}
 
 		[BeginAction("udbscriptexecuteslot1")]
@@ -665,7 +670,7 @@ namespace CodeImp.DoomBuilder.UDBScript
 				if (scriptslots.ContainsKey(slot) && scriptslots[slot] != null)
 				{
 					scriptrunner = new ScriptRunner(scriptslots[slot]);
-					scriptrunner.Run();
+					//scriptrunner.Run();
 				}
 			}
 		}

--- a/Source/Plugins/UDBScript/ProgressInfo.cs
+++ b/Source/Plugins/UDBScript/ProgressInfo.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CodeImp.DoomBuilder.UDBScript
+{
+	class ProgressInfo
+	{
+		IProgress<int> progress;
+		IProgress<string> status;
+		IProgress<string> _log;
+
+		public ProgressInfo(IProgress<int> progress, IProgress<string> status, IProgress<string> log)
+		{
+			this.progress = progress;
+			this.status = status;
+			_log = log;
+		}
+
+		public void setProgress(int p)
+		{
+			progress.Report(p);
+		}
+		
+		public void setStatus(string s)
+		{
+			status.Report(s);
+		}
+
+		public void log(string s)
+		{
+			_log.Report(s);
+		}
+	}
+}

--- a/Source/Plugins/UDBScript/UDBScript.csproj
+++ b/Source/Plugins/UDBScript/UDBScript.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Controls\ScriptOptionsControl.Designer.cs">
       <DependentUpon>ScriptOptionsControl.cs</DependentUpon>
     </Compile>
+    <Compile Include="ProgressInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
@@ -122,6 +123,12 @@
     </Compile>
     <Compile Include="Windows\QueryOptionsForm.Designer.cs">
       <DependentUpon>QueryOptionsForm.cs</DependentUpon>
+    </Compile>
+    <Compile Include="Windows\ScriptRunnerForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Windows\ScriptRunnerForm.Designer.cs">
+      <DependentUpon>ScriptRunnerForm.cs</DependentUpon>
     </Compile>
     <Compile Include="Windows\UDBScriptErrorForm.cs">
       <SubType>Form</SubType>
@@ -161,6 +168,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Windows\QueryOptionsForm.resx">
       <DependentUpon>QueryOptionsForm.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Windows\ScriptRunnerForm.resx">
+      <DependentUpon>ScriptRunnerForm.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Windows\UDBScriptErrorForm.resx">
       <DependentUpon>UDBScriptErrorForm.cs</DependentUpon>

--- a/Source/Plugins/UDBScript/Windows/ScriptRunnerForm.Designer.cs
+++ b/Source/Plugins/UDBScript/Windows/ScriptRunnerForm.Designer.cs
@@ -1,0 +1,110 @@
+﻿namespace CodeImp.DoomBuilder.UDBScript
+{
+	partial class ScriptRunnerForm
+	{
+		/// <summary>
+		/// Required designer variable.
+		/// </summary>
+		private System.ComponentModel.IContainer components = null;
+
+		/// <summary>
+		/// Clean up any resources being used.
+		/// </summary>
+		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing && (components != null))
+			{
+				components.Dispose();
+			}
+			base.Dispose(disposing);
+		}
+
+		#region Windows Form Designer generated code
+
+		/// <summary>
+		/// Required method for Designer support - do not modify
+		/// the contents of this method with the code editor.
+		/// </summary>
+		private void InitializeComponent()
+		{
+			this.progressbar = new System.Windows.Forms.ProgressBar();
+			this.lbStatus = new System.Windows.Forms.Label();
+			this.btnAction = new System.Windows.Forms.Button();
+			this.tbLog = new System.Windows.Forms.TextBox();
+			this.SuspendLayout();
+			// 
+			// progressbar
+			// 
+			this.progressbar.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+			this.progressbar.Location = new System.Drawing.Point(12, 25);
+			this.progressbar.Name = "progressbar";
+			this.progressbar.Size = new System.Drawing.Size(419, 23);
+			this.progressbar.Step = 1;
+			this.progressbar.Style = System.Windows.Forms.ProgressBarStyle.Continuous;
+			this.progressbar.TabIndex = 0;
+			// 
+			// lbStatus
+			// 
+			this.lbStatus.AutoSize = true;
+			this.lbStatus.Location = new System.Drawing.Point(12, 9);
+			this.lbStatus.Name = "lbStatus";
+			this.lbStatus.Size = new System.Drawing.Size(84, 13);
+			this.lbStatus.TabIndex = 1;
+			this.lbStatus.Text = "Running script...";
+			// 
+			// btnAction
+			// 
+			this.btnAction.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+			this.btnAction.Location = new System.Drawing.Point(437, 25);
+			this.btnAction.Name = "btnAction";
+			this.btnAction.Size = new System.Drawing.Size(75, 23);
+			this.btnAction.TabIndex = 2;
+			this.btnAction.Text = "Cancel";
+			this.btnAction.UseVisualStyleBackColor = true;
+			this.btnAction.Click += new System.EventHandler(this.btnAction_Click);
+			// 
+			// tbLog
+			// 
+			this.tbLog.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+			this.tbLog.Location = new System.Drawing.Point(12, 54);
+			this.tbLog.Multiline = true;
+			this.tbLog.Name = "tbLog";
+			this.tbLog.ReadOnly = true;
+			this.tbLog.ScrollBars = System.Windows.Forms.ScrollBars.Both;
+			this.tbLog.Size = new System.Drawing.Size(500, 118);
+			this.tbLog.TabIndex = 3;
+			// 
+			// ScriptRunnerForm
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.ClientSize = new System.Drawing.Size(524, 184);
+			this.ControlBox = false;
+			this.Controls.Add(this.tbLog);
+			this.Controls.Add(this.btnAction);
+			this.Controls.Add(this.lbStatus);
+			this.Controls.Add(this.progressbar);
+			this.MinimumSize = new System.Drawing.Size(540, 200);
+			this.Name = "ScriptRunnerForm";
+			this.ShowIcon = false;
+			this.Text = "Running script";
+			this.WindowState = System.Windows.Forms.FormWindowState.Minimized;
+			this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.ScriptRunnerForm_FormClosed);
+			this.Shown += new System.EventHandler(this.ScriptRunnerForm_Shown);
+			this.ResumeLayout(false);
+			this.PerformLayout();
+
+		}
+
+		#endregion
+
+		private System.Windows.Forms.ProgressBar progressbar;
+		private System.Windows.Forms.Label lbStatus;
+		private System.Windows.Forms.Button btnAction;
+		private System.Windows.Forms.TextBox tbLog;
+	}
+}

--- a/Source/Plugins/UDBScript/Windows/ScriptRunnerForm.cs
+++ b/Source/Plugins/UDBScript/Windows/ScriptRunnerForm.cs
@@ -1,0 +1,334 @@
+﻿#region ================== Copyright (c) 2022 Boris Iwanski
+
+/*
+ * This program is free software: you can redistribute it and/or modify
+ *
+ * it under the terms of the GNU General Public License as published by
+ * 
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * 
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.If not, see<http://www.gnu.org/licenses/>.
+ */
+
+#endregion
+
+#region ================== Namespaces
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using CodeImp.DoomBuilder.Windows;
+
+#endregion
+
+namespace CodeImp.DoomBuilder.UDBScript
+{
+	public partial class ScriptRunnerForm : DelayedForm
+	{
+		#region ================== Constants
+
+		/// <summary>
+		/// How long a script is allowed to run until the form is made visible.
+		/// </summary>
+		const int RUNTIME_THRESHOLD = 1000;
+
+		#endregion
+
+		#region ================== Variables
+
+		/// <summary>
+		/// Cancellation token for stopping the script.
+		/// </summary>
+		CancellationTokenSource cancellationtokensource;
+
+		/// <summary>
+		/// If script is currently executed or not.
+		/// </summary>
+		bool running;
+
+		/// <summary>
+		/// How many milliseconds the script has been running
+		/// </summary>
+		double runningseconds;
+
+		/// <summary>
+		/// Determines if the form should be automatically closed when the script is finished.
+		/// </summary>
+		bool autoclose;
+
+		/// <summary>
+		/// Stopwatch used to determine how long the script is already running.
+		/// </summary>
+		Stopwatch stopwatch;
+
+		/// <summary>
+		/// Timer for making the form visible when the script is running for too long.
+		/// </summary>
+		System.Windows.Forms.Timer timer;
+
+
+		#endregion
+
+		#region ================== Methods
+
+		public ScriptRunnerForm()
+		{
+			InitializeComponent();
+		}
+
+		/// <summary>
+		/// Invokes a method, but stops the timer before running the code, and starting the timer after the code ran.
+		/// </summary>
+		/// <param name="method">Method to invoke</param>
+		/// <returns>Return value of the method</returns>
+		public object InvokePaused(Delegate method)
+		{
+			if (InvokeRequired)
+			{
+				return Invoke(new Action(() => InvokePaused(method)));
+			}
+			else
+			{
+				stopwatch.Stop();
+				object result = Invoke(method);
+				stopwatch.Start();
+				return result;
+			}
+		}
+
+		/// <summary>
+		/// Invokes a method.
+		/// </summary>
+		/// <param name="action">Method to invoke</param>
+		public void RunAction(Action action)
+		{
+			if (InvokeRequired)
+				Invoke(action);
+			else
+				action();
+		}
+
+		/// <summary>
+		/// Sets the value of the progress bar (in the range from 0 to 100).
+		/// </summary>
+		/// <param name="value">Value of the progress bar (in the range from 0 to 100)</param>
+		private void SetProgress(int value)
+		{
+			if (progressbar.Style != ProgressBarStyle.Continuous)
+				progressbar.Style = ProgressBarStyle.Continuous;
+
+			// Do some trickery to remove the movement of the progress bar, since it can
+			// otherwise screw with how much the progress bar is filled
+			if (progressbar.Value != value)
+			{
+				if (value > progressbar.Maximum)
+					value = progressbar.Maximum;
+				else if (value < progressbar.Minimum)
+					value = progressbar.Minimum;
+
+				if (progressbar.Maximum == value)
+				{
+					progressbar.Value = value;
+					progressbar.Value = value - 1;
+				}
+				else
+				{
+					progressbar.Value = value + 1;
+				}
+				progressbar.Value = value;
+			}
+
+			// Make the form visible so that the user can actually see the progress bar
+			MakeVisible();
+		}
+
+		private void SetProgressStatus(string status)
+		{
+			lbStatus.Text = status;
+		}
+
+		private void Log(string text)
+		{
+			// If there's something in the log we don't want to automatically
+			// close the form, otherwise the user could not read the contents
+			autoclose = false;
+
+			// Since we don't want to have a useless line at the end of the textbox
+			// we add a new line before adding the new text (unless there's no text
+			// at all yet, then we don't add a new line
+			if (!string.IsNullOrEmpty(tbLog.Text))
+				tbLog.AppendText(Environment.NewLine);
+
+			// Add the new text
+			tbLog.AppendText(text);
+
+			// Make the form visible so that the user can actually see the status bar
+			MakeVisible();
+		}
+
+		private async void RunScript(CancellationToken cancellationtoken)
+		{
+			// Callbacks for setting the progress bar, status text, and adding log lines from the script
+			Progress<int> progress = new Progress<int>(SetProgress);
+			Progress<string> status = new Progress<string>(SetProgressStatus);
+			Progress<string> log = new Progress<string>(Log);
+
+			running = true;
+
+			// Prepare running the script
+			BuilderPlug.Me.ScriptRunner.PreRun(cancellationtoken);
+
+			try
+			{
+				await Task.Run(() => BuilderPlug.Me.ScriptRunner.Run(progress, status, log));
+				stopwatch.Stop();
+			}
+			catch (Exception ex)
+			{
+				stopwatch.Stop();
+				BuilderPlug.Me.ScriptRunner.HandleExceptions(ex);
+			}
+
+			// Clean up and update after running the script
+			BuilderPlug.Me.ScriptRunner.PostRun();
+
+			running = false;
+
+			btnAction.Text = "Close";
+			btnAction.Enabled = true;
+
+			if (autoclose)
+			{
+				MakeInvisible();
+				//Hide();
+				Close();
+			}
+		}
+
+		/// <summary>
+		/// Makes the form visible.
+		/// </summary>
+		private void MakeVisible()
+		{
+			Opacity = 1.0;
+			btnAction.Enabled = true;
+		}
+
+		/// <summary>
+		/// Makes the form invisible.
+		/// </summary>
+		private void MakeInvisible()
+		{
+			Opacity = 0.0;
+		}
+
+		#endregion
+
+		#region ================== Events
+
+		/// <summary>
+		/// Cancels the currently running script, or closes the form if no script is running.
+		/// </summary>
+		/// <param name="sender">The sender</param>
+		/// <param name="e">Event arguments</param>
+		private void btnAction_Click(object sender, EventArgs e)
+		{
+			if (running)
+			{
+				btnAction.Enabled = false;
+				cancellationtokensource.Cancel();
+			}
+			else
+			{
+				MakeInvisible();
+				//Hide();
+				Close();
+			}
+		}
+
+		/// <summary>
+		/// Sets everything up for running the script, and then immediately runs the script.
+		/// </summary>
+		/// <param name="sender">The sender</param>
+		/// <param name="e">Event arguments</param>
+		private void ScriptRunnerForm_Shown(object sender, EventArgs e)
+		{
+			cancellationtokensource = new CancellationTokenSource();
+			autoclose = true;
+			runningseconds = 0;
+
+			progressbar.Value = 0;
+			progressbar.Style = ProgressBarStyle.Marquee;
+
+			Text = "Running script";
+			lbStatus.Text = "Running script...";
+
+			btnAction.Text = "Cancel";
+			// Disable the button because it could otherwise be pressed while the form is invisible.
+			// It'll be enabled as soon as the form is made visible
+			btnAction.Enabled = false;
+
+			tbLog.Clear();
+
+			// The timer ticks ever 100ms. The method it runs checks how long the script is running
+			// and makes the form visible if the runtime threshold has been reached
+			timer = new System.Windows.Forms.Timer();
+			timer.Interval = 100;
+			timer.Tick += timerShow_Tick;
+			timer.Start();
+
+			// This stopwatch is used to measure how long the script has been running
+			stopwatch = new Stopwatch();
+			stopwatch.Start();
+
+			// Start running the script
+			RunScript(cancellationtokensource.Token);
+		}
+
+		protected override void OnLoad(EventArgs e)
+		{
+			base.OnLoad(e);
+
+			MakeInvisible();
+		}
+
+		/// <summary>
+		/// Makes the form visible if the runtime threshold has been reached. Shows the elapsed time the script is running.
+		/// </summary>
+		/// <param name="sender">The sender</param>
+		/// <param name="e">Event arguments</param>
+		private void timerShow_Tick(object sender, EventArgs e)
+		{
+			if (Opacity == 0.0 && stopwatch.ElapsedMilliseconds > 1000)
+			{
+				MakeVisible();
+			}
+
+			double newrunningsecods = Math.Floor(stopwatch.Elapsed.TotalSeconds);
+
+			if(newrunningsecods > runningseconds)
+			{
+				runningseconds = newrunningsecods;
+				Text = "Running script (" + string.Format("{0:D2}:{1:D2}:{2:D2}", stopwatch.Elapsed.Hours, stopwatch.Elapsed.Minutes, stopwatch.Elapsed.Seconds) + ")";
+			}
+		}
+
+		private void ScriptRunnerForm_FormClosed(object sender, FormClosedEventArgs e)
+		{
+			timer.Stop();
+		}
+
+		#endregion
+	}
+}

--- a/Source/Plugins/UDBScript/Windows/ScriptRunnerForm.resx
+++ b/Source/Plugins/UDBScript/Windows/ScriptRunnerForm.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>


### PR DESCRIPTION
Currently scripts are run on the UI thread. The issue with that is that long running scripts will lock up the application ("this application is not responding") until the script finishes running. It's also possible to have infinite loops in script. To counter this UDBScript has a [constraint](https://github.com/jewalky/UltimateDoomBuilder/blob/12f32e2bc60d1d6316d4d88d144833ad38db3807/Source/Plugins/UDBScript/RuntimeConstraint.cs) that checks how long a script has been running, and asks the user every 5 seconds if the script should keep executing or be stopped.

This is fine for scripts are running only a bit longer than 5 seconds, or for scripts that are accidentally running that long. However, there can be cases when a long running script is expected, and hitting a button every 5 seconds to keep it going is annoying.

The best solution is to run the script on another thread to keep the UI responsive. This also adds the possibility of more control for the user and script authors for communicating with the user. This PR implements such changes.

Doing anything map related on non-UI-threads is a delicate thing. While reading the map is generally no problem (that's what for example the error checker does), but changing the map is problematic, since it's not thread-safe.
To not run into problems some changes had to be made to code that's not directly related to UDBScript:

- added `IsSafeToAccess` property to `MapSet`. This is purely conventional and has to be set and respected by other code. This is currently used for the comments docker, since that reads the map every 2 seconds (i.e. UDBScript sets `IsSafeToAccess` to `false` and the comments docker doesn't update if it is set to `false`)
- it's not possible any longer to use the scroll wheel to zoom in/out while a modal dialog is open (since that could result in reading the map while a script modifies it). I assume that was a bug/oversight in the first place, so I think it's not much of a problem
- `processingcount` from the main window is exposed as a read-only property. This variable is increased/decreased when `EnableProcessing`/`DisableProcessing` is used (for example to show animations in Visual Mode and Make Sectors Mode)

There are also changes on how scripts are run:

- a form is opened (but made invisible immediately) that contains a button to cancel the script, a progress bar, and a log text box
- running the script is prepared on the UI thread
- script is run on another thread
- post-run is executed on the UI thread

The form gets shown when one of the following conditions are met:

- the script is running for at least 1 second
- the progress bar value is set from within the script
- the "status" (label above the progess bar) is set
- a log entry is added

How it looks like: https://youtu.be/QnsIrgSBe5w
