### PR TITLE
Hotfix for potential crash if COLORMAP or PLAYPAL don't have expected size

### DIFF
--- a/Source/Core/Data/ColorMap.cs
+++ b/Source/Core/Data/ColorMap.cs
@@ -77,8 +77,15 @@ namespace CodeImp.DoomBuilder.Data
 			{
 				// Read colors
 				var index = reader.ReadByte();
-				var color = palette[index];
-				colors.Add(color);
+				if (index < palette.Length)
+				{
+					var color = palette[index];
+					colors.Add(color);					
+				}
+				else
+				{
+					colors.Add(PixelColor.Transparent);
+				}
 			}
 
 			this.colors = colors.ToArray();
@@ -96,7 +103,10 @@ namespace CodeImp.DoomBuilder.Data
 			for (int y = 0; y < height; y++) {
 				for (int x = 0; x < width; x++) {
 					int index = width * y + x;
-					bitmap.SetPixel(x, y, colors[index].ToColor());
+					if (index < colors.Length)
+					{
+						bitmap.SetPixel(x, y, colors[index].ToColor());						
+					}
 				}
 			}
 			return bitmap;

--- a/Source/Core/Data/Playpal.cs
+++ b/Source/Core/Data/Playpal.cs
@@ -41,6 +41,7 @@ namespace CodeImp.DoomBuilder.Data
 		#region ================== Properties
 
 		public PixelColor this[int index] { get { return colors[index]; } }
+		public int Length { get { return colors.Length;  } }
 		
 		#endregion
 
@@ -92,7 +93,10 @@ namespace CodeImp.DoomBuilder.Data
 			for (int y = 0; y < 16; y++) {
 				for (int x = 0; x < 16; x++) {
 					int index = 16 * y + x;
-					bitmap.SetPixel(x, y, colors[index].ToColor());
+					if (index < colors.Length)
+					{
+						bitmap.SetPixel(x, y, colors[index].ToColor());						
+					}
 				}
 			}
 			return bitmap;


### PR DESCRIPTION
Someone in Discord reported a crash caused by an out-of-bounds index access in ColorMap.CreateBitmap(). I realized it makes an assumption that the lump is the correct size, so this hotfix should correct the possibility of a crash in that circumstance.