### PR TITLE
Made classic rendererer respect per-surface light levels

### DIFF
--- a/Source/Core/Data/ImageData.cs
+++ b/Source/Core/Data/ImageData.cs
@@ -308,7 +308,7 @@ namespace CodeImp.DoomBuilder.Data
             // Do the loading
             LocalLoadResult loadResult = LocalLoadImage();
 
-            MakeUncorrectedImage(loadResult, usecolorcorrection);
+            MakeUncorrectedImage(loadResult);
             ConvertImageFormat(loadResult, usecolorcorrection);
             MakeImagePreview(loadResult);
             MakeAlphaTestImage(loadResult);
@@ -603,20 +603,12 @@ namespace CodeImp.DoomBuilder.Data
         // Dimensions of a single preview image
         const int MAX_PREVIEW_SIZE = 256; //mxd
 
-        // This makes a copy of the image before color correction or, if color correction is disabled for this image,
-        // just references the original bitmap.
-        private void MakeUncorrectedImage(LocalLoadResult loadResult, bool usecolorcorrection)
+        // This makes a copy of the image before color correction
+        private void MakeUncorrectedImage(LocalLoadResult loadResult)
         {
 	        if (loadResult.bitmap == null)
 		        return;
-	        if (usecolorcorrection)
-	        {
-		        loadResult.uncorrected = new Bitmap(loadResult.bitmap);
-	        }
-	        else
-	        {
-		        loadResult.uncorrected = loadResult.bitmap;
-	        }
+	        loadResult.uncorrected = new Bitmap(loadResult.bitmap);
         }
 
         // This makes a preview for the given image and updates the image settings

--- a/Source/Core/Rendering/RenderDevice.cs
+++ b/Source/Core/Rendering/RenderDevice.cs
@@ -74,7 +74,8 @@ namespace CodeImp.DoomBuilder.Rendering
             // volte: classic rendering
             DeclareUniform(UniformName.drawPaletted, "drawPaletted", UniformType.Int);
             DeclareUniform(UniformName.colormapSize, "colormapSize", UniformType.Vec2i);
-            DeclareUniform(UniformName.lightLevel, "lightLevel", UniformType.Int);
+            DeclareUniform(UniformName.doomlightlevels, "doomlightlevels", UniformType.Int);
+            DeclareUniform(UniformName.sectorLightLevel, "sectorLightLevel", UniformType.Int);
 
             // 2d fsaa
             CompileShader(ShaderName.display2d_fsaa, "display2d.shader", "display2d_fsaa");
@@ -802,7 +803,8 @@ namespace CodeImp.DoomBuilder.Rendering
 		slopeHandleLength,
         drawPaletted,
         colormapSize,
-        lightLevel
+        sectorLightLevel,
+        doomlightlevels
     }
 
     public enum VertexFormat : int { Flat, World }

--- a/Source/Core/Rendering/Renderer3D.cs
+++ b/Source/Core/Rendering/Renderer3D.cs
@@ -355,6 +355,7 @@ namespace CodeImp.DoomBuilder.Rendering
 			graphics.SetUniform(UniformName.fogsettings, new Vector4f(-1.0f));
 			graphics.SetUniform(UniformName.fogcolor, General.Colors.Background.ToColorValue());
 			graphics.SetUniform(UniformName.texturefactor, new Color4(1f, 1f, 1f, 1f));
+			graphics.SetUniform(UniformName.doomlightlevels, General.Map.Config.DoomLightLevels);
             graphics.SetUniform(UniformName.highlightcolor, new Color4()); //mxd
             TextureFilter texFilter = (!General.Settings.ClassicRendering && General.Settings.VisualBilinear) ? TextureFilter.Linear : TextureFilter.Nearest;
             MipmapFilter mipFilter = General.Settings.ClassicRendering ? MipmapFilter.None : MipmapFilter.Linear;
@@ -950,7 +951,7 @@ namespace CodeImp.DoomBuilder.Rendering
 						}
 						
 						// volte: set sector light level for classic rendering mode
-						graphics.SetUniform(UniformName.lightLevel, sector.Sector.Brightness);
+						graphics.SetUniform(UniformName.sectorLightLevel, sector.Sector.Brightness);
 
 						//mxd. Set variables for fog rendering?
 						if(wantedshaderpass > ShaderName.world3d_p7)
@@ -1060,7 +1061,7 @@ namespace CodeImp.DoomBuilder.Rendering
 							// Set the colors to use
 							if (t.Thing.Sector != null)
 							{
-								graphics.SetUniform(UniformName.lightLevel, t.Thing.Sector.Brightness);
+								graphics.SetUniform(UniformName.sectorLightLevel, t.Thing.Sector.Brightness);
 								graphics.SetUniform(UniformName.sectorfogcolor, t.Thing.Sector.FogColor);
 							}
                             graphics.SetUniform(UniformName.vertexColor, vertexcolor);

--- a/Source/Core/Rendering/Shaders/ShaderCompiler.cs
+++ b/Source/Core/Rendering/Shaders/ShaderCompiler.cs
@@ -156,8 +156,17 @@ namespace CodeImp.DoomBuilder.Rendering.Shaders
                     output += string.Format("layout(location = {0}) ", location);
                 }
 
-                output += prefix + " ";
-                output += field.TypeName;
+                string typeName = field.TypeName;
+                string flat = "";
+
+                if (typeName.EndsWith("_flat"))
+                {
+                    flat = "flat ";
+                    typeName = typeName.Remove(typeName.Length - 5, 5);
+                }
+
+                output += flat + prefix + " ";
+                output += typeName;
 
                 if (field.ArrayDimensions != null)
                 {


### PR DESCRIPTION
This PR makes the classic renderer take its brightness level from the brightness of the computed vertex colors (which is how the regular renderer modulates brightness) rather than the raw sector brightness, which means per-surface light levels such as from UDMF properties or Boom transfers will be respected. I've done pretty extensive testing to make sure that the brightness is computed identically to the previous method.

This PR also fixes a crash that could occur when loading non-color-corrected images (non-texture images like built-in resource images).