### PR TITLE
Vertex rendering options

### DIFF
--- a/Source/Core/Config/ProgramConfiguration.cs
+++ b/Source/Core/Config/ProgramConfiguration.cs
@@ -418,8 +418,8 @@ namespace CodeImp.DoomBuilder.Config
 
 				// volte
 				classicRendering = cfg.ReadSetting("classicrendering", false);
-				alwaysShowVertices = cfg.ReadSetting("alwaysShowVertices", true);
-				flatShadeVertices = cfg.ReadSetting("flatShadeVertices", false);
+				alwaysShowVertices = cfg.ReadSetting("alwaysshowvertices", true);
+				flatShadeVertices = cfg.ReadSetting("flatshadevertices", false);
 				
 				//mxd. Sector defaults
 				defaultceilheight = cfg.ReadSetting("defaultceilheight", 128);
@@ -563,8 +563,8 @@ namespace CodeImp.DoomBuilder.Config
 
 			//volte
 			cfg.WriteSetting("classicrendering", classicRendering);
-			cfg.WriteSetting("alwaysShowVertices", alwaysShowVertices);
-			cfg.WriteSetting("flatShadeVertices", flatShadeVertices);
+			cfg.WriteSetting("alwaysshowvertices", alwaysShowVertices);
+			cfg.WriteSetting("flatshadevertices", flatShadeVertices);
 			
 			//mxd. Sector defaults
 			cfg.WriteSetting("defaultceilheight", defaultceilheight);

--- a/Source/Core/Config/ProgramConfiguration.cs
+++ b/Source/Core/Config/ProgramConfiguration.cs
@@ -148,6 +148,8 @@ namespace CodeImp.DoomBuilder.Config
 		
 		//volte
 		private bool classicRendering;
+		private bool flatShadeVertices;
+		private bool alwaysShowVertices;
 		
 		// These are not stored in the configuration, only used at runtime
 		private int defaultbrightness;
@@ -276,6 +278,10 @@ namespace CodeImp.DoomBuilder.Config
 		
 		//volte
 		public bool ClassicRendering { get { return classicRendering; } internal set { classicRendering = value; } }
+
+		public bool FlatShadeVertices {  get { return flatShadeVertices; } internal set { flatShadeVertices = value;  } }
+
+		public bool AlwaysShowVertices {  get { return alwaysShowVertices; } internal set { alwaysShowVertices = value; } }
 
 		//mxd. Left here for compatibility reasons...
 		public string DefaultTexture { get { return General.Map != null ? General.Map.Options.DefaultWallTexture : "-"; } set { if(General.Map != null) General.Map.Options.DefaultWallTexture = value; } }
@@ -412,6 +418,8 @@ namespace CodeImp.DoomBuilder.Config
 
 				// volte
 				classicRendering = cfg.ReadSetting("classicrendering", false);
+				alwaysShowVertices = cfg.ReadSetting("alwaysShowVertices", true);
+				flatShadeVertices = cfg.ReadSetting("flatShadeVertices", false);
 				
 				//mxd. Sector defaults
 				defaultceilheight = cfg.ReadSetting("defaultceilheight", 128);
@@ -555,6 +563,8 @@ namespace CodeImp.DoomBuilder.Config
 
 			//volte
 			cfg.WriteSetting("classicrendering", classicRendering);
+			cfg.WriteSetting("alwaysShowVertices", alwaysShowVertices);
+			cfg.WriteSetting("flatShadeVertices", flatShadeVertices);
 			
 			//mxd. Sector defaults
 			cfg.WriteSetting("defaultceilheight", defaultceilheight);

--- a/Source/Core/Editing/ClassicMode.cs
+++ b/Source/Core/Editing/ClassicMode.cs
@@ -89,6 +89,9 @@ namespace CodeImp.DoomBuilder.Editing
 
 		#region ================== Properties
 		
+		// If false, then vertices will not be drawn if "hide vertices outside vertex mode" is enabled
+		public virtual bool AlwaysShowVertices { get { return false;  } }
+		
 		// Mouse status
 		public Vector2D MousePos { get { return mousepos; } }
 		public Vector2D MouseLastPos { get { return mouselastpos; } }

--- a/Source/Core/Rendering/IRenderer2D.cs
+++ b/Source/Core/Rendering/IRenderer2D.cs
@@ -64,9 +64,9 @@ namespace CodeImp.DoomBuilder.Rendering
 		void PlotLinedefSet(ICollection<Linedef> linedefs);
 		void PlotSector(Sector s);
 		void PlotSector(Sector s, PixelColor c);
-		void PlotVertex(Vertex v, int colorindex);
-		void PlotVertexAt(Vector2D v, int colorindex);
-		void PlotVerticesSet(ICollection<Vertex> vertices);
+		void PlotVertex(Vertex v, int colorindex, bool checkMode = true);
+		void PlotVertexAt(Vector2D v, int colorindex, bool checkMode = true);
+		void PlotVerticesSet(ICollection<Vertex> vertices, bool checkMode = true);
 		void RenderThing(Thing t, PixelColor c, float alpha);
 		void RenderThingSet(ICollection<Thing> things, float alpha);
 		void RenderRectangle(RectangleF rect, float bordersize, PixelColor c, bool transformrect);

--- a/Source/Core/Rendering/Plotter.cs
+++ b/Source/Core/Rendering/Plotter.cs
@@ -128,23 +128,26 @@ namespace CodeImp.DoomBuilder.Rendering
                     for (int xp = x1; xp <= x2; xp++)
                         pixels[yp * width + xp] = c;
 
-                // Vertical edges
-                for (int yp = y1 + 1; yp <= y2 - 1; yp++)
+                if (!General.Settings.FlatShadeVertices)
                 {
-                    pixels[yp * width + x1] = l;
-                    pixels[yp * width + x2] = d;
-                }
+                    // Vertical edges
+                    for (int yp = y1 + 1; yp <= y2 - 1; yp++)
+                    {
+                        pixels[yp * width + x1] = l;
+                        pixels[yp * width + x2] = d;
+                    }
 
-                // Horizontal edges
-                for (int xp = x1 + 1; xp <= x2 - 1; xp++)
-                {
-                    pixels[y1 * width + xp] = l;
-                    pixels[y2 * width + xp] = d;
-                }
+                    // Horizontal edges
+                    for (int xp = x1 + 1; xp <= x2 - 1; xp++)
+                    {
+                        pixels[y1 * width + xp] = l;
+                        pixels[y2 * width + xp] = d;
+                    }
 
-                // Corners
-                pixels[y2 * width + x2] = d;
-                pixels[y1 * width + x1] = l;
+                    // Corners
+                    pixels[y2 * width + x2] = d;
+                    pixels[y1 * width + x1] = l;
+                }
             }
             /*
 			else

--- a/Source/Core/Rendering/Renderer2D.cs
+++ b/Source/Core/Rendering/Renderer2D.cs
@@ -2116,8 +2116,12 @@ namespace CodeImp.DoomBuilder.Rendering
 		}
 
 		// This renders a single vertex
-		public void PlotVertex(Vertex v, int colorindex)
+		public void PlotVertex(Vertex v, int colorindex, bool checkMode = true)
 		{
+			if (checkMode && !ShouldRenderVertices)
+			{
+				return;
+			}
 			// Transform vertex coordinates
 			Vector2D nv = v.Position.GetTransformed(translatex, translatey, scale, -scale);
 
@@ -2126,8 +2130,13 @@ namespace CodeImp.DoomBuilder.Rendering
 		}
 
 		// This renders a single vertex at specified coordinates
-		public void PlotVertexAt(Vector2D v, int colorindex)
+		public void PlotVertexAt(Vector2D v, int colorindex, bool checkMode = true)
 		{
+			if (checkMode && !ShouldRenderVertices)
+			{
+				return;
+			}
+			
 			// Transform vertex coordinates
 			Vector2D nv = v.GetTransformed(translatex, translatey, scale, -scale);
 
@@ -2136,10 +2145,27 @@ namespace CodeImp.DoomBuilder.Rendering
 		}
 		
 		// This renders a set of vertices
-		public void PlotVerticesSet(ICollection<Vertex> vertices)
+		public void PlotVerticesSet(ICollection<Vertex> vertices, bool checkMode = true)
 		{
+			if (checkMode && !ShouldRenderVertices)
+			{
+				return;
+			}
+			
 			// Go for all vertices
 			foreach(Vertex v in vertices) PlotVertex(v, DetermineVertexColor(v));
+		}
+
+		private bool ShouldRenderVertices
+		{
+			get
+			{
+				if (!(General.Editing.Mode is ClassicMode mode))
+				{
+					return true; 
+				}
+				return mode.AlwaysShowVertices || General.Settings.AlwaysShowVertices;
+			}
 		}
 
 		#endregion

--- a/Source/Core/Rendering/Renderer2D.cs
+++ b/Source/Core/Rendering/Renderer2D.cs
@@ -125,10 +125,22 @@ namespace CodeImp.DoomBuilder.Rendering
 		public SurfaceManager Surfaces { get { return surfaces; } }
 		public RectangleF Viewport { get { return viewport; } } //mxd
 
+		private bool ShouldRenderVertices
+		{
+			get
+			{
+				if (!(General.Editing.Mode is ClassicMode mode))
+				{
+					return true;
+				}
+				return mode.AlwaysShowVertices || General.Settings.AlwaysShowVertices;
+			}
+		}
+
 		#endregion
 
 		#region ================== Constructor / Disposer
-		
+
 		// Constructor
 		internal Renderer2D(RenderDevice graphics) : base(graphics)
 		{
@@ -2154,18 +2166,6 @@ namespace CodeImp.DoomBuilder.Rendering
 			
 			// Go for all vertices
 			foreach(Vertex v in vertices) PlotVertex(v, DetermineVertexColor(v));
-		}
-
-		private bool ShouldRenderVertices
-		{
-			get
-			{
-				if (!(General.Editing.Mode is ClassicMode mode))
-				{
-					return true; 
-				}
-				return mode.AlwaysShowVertices || General.Settings.AlwaysShowVertices;
-			}
 		}
 
 		#endregion

--- a/Source/Core/Resources/Actions.cfg
+++ b/Source/Core/Resources/Actions.cfg
@@ -1157,7 +1157,17 @@ togglefixedthingsscale //mxd
 	allowmouse = false;
 	allowscroll = false;
 }
-
+	
+togglealwaysshowvertices
+{
+	title = "Toggle Always Show Vertices";
+	category = "view";
+	description = "When enabled, vertices will always be drawn, regardless of the current mode.";
+	allowkeys = true;
+	allowmouse = false;
+	allowscroll = false;
+}
+	
 togglebrightness //mxd
 {
 	title = "Toggle Full Brightness";

--- a/Source/Core/Windows/MainForm.Designer.cs
+++ b/Source/Core/Windows/MainForm.Designer.cs
@@ -288,6 +288,7 @@ namespace CodeImp.DoomBuilder.Windows
 			this.modecontrolsloolbar = new System.Windows.Forms.ToolStrip();
 			this.itemtogglecomments = new System.Windows.Forms.ToolStripMenuItem();
 			this.itemtogglefixedthingsscale = new System.Windows.Forms.ToolStripMenuItem();
+			this.itemtogglealwaysshowvertices = new System.Windows.Forms.ToolStripMenuItem();
 			this.itemdynamicgridsize = new System.Windows.Forms.ToolStripMenuItem();
 			this.itemaligngridtolinedef = new System.Windows.Forms.ToolStripMenuItem();
 			this.itemsetgridorigintovertex = new System.Windows.Forms.ToolStripMenuItem();
@@ -795,6 +796,7 @@ namespace CodeImp.DoomBuilder.Windows
 			this.itemtogglegrid,
 			this.itemtogglecomments,
 			this.itemtogglefixedthingsscale,
+			this.itemtogglealwaysshowvertices,
 			this.separatorrendering,
 			this.itemdynlightmodes,
 			this.itemmodelmodes,
@@ -2831,6 +2833,17 @@ namespace CodeImp.DoomBuilder.Windows
 			this.itemtogglefixedthingsscale.Text = "Fixed Things Scale";
 			this.itemtogglefixedthingsscale.Click += new System.EventHandler(this.InvokeTaggedAction);
 			// 
+			// itemtogglealwaysshowvertices
+			// 
+			this.itemtogglealwaysshowvertices.Checked = true;
+			this.itemtogglealwaysshowvertices.CheckOnClick = true;
+			this.itemtogglealwaysshowvertices.CheckState = System.Windows.Forms.CheckState.Checked;
+			this.itemtogglealwaysshowvertices.Name = "itemtogglealwaysshowvertices";
+			this.itemtogglealwaysshowvertices.Size = new System.Drawing.Size(215, 22);
+			this.itemtogglealwaysshowvertices.Tag = "builder_togglealwaysshowvertices";
+			this.itemtogglealwaysshowvertices.Text = "Always Show Vertices";
+			this.itemtogglealwaysshowvertices.Click += new System.EventHandler(this.InvokeTaggedAction);
+			// 
 			// itemdynamicgridsize
 			// 
 			this.itemdynamicgridsize.Checked = true;
@@ -3136,5 +3149,6 @@ namespace CodeImp.DoomBuilder.Windows
 		private ToolStripMenuItem itemdynamicgridsize;
 		private ToolStripMenuItem itemtogglecomments;
 		private ToolStripMenuItem itemtogglefixedthingsscale;
+		private ToolStripMenuItem itemtogglealwaysshowvertices;
 	}
 }

--- a/Source/Core/Windows/MainForm.cs
+++ b/Source/Core/Windows/MainForm.cs
@@ -2951,6 +2951,19 @@ namespace CodeImp.DoomBuilder.Windows
 			// Redraw display to show changes
 			RedrawDisplay();
 		}
+		
+		//mxd. Action to toggle fixed things scale
+		[BeginAction("togglealwaysshowvertices")]
+		internal void ToggleAlwaysShowVertices()
+		{
+			General.Settings.AlwaysShowVertices = !General.Settings.AlwaysShowVertices;
+			itemtogglealwaysshowvertices.Checked = General.Settings.AlwaysShowVertices;
+			
+			DisplayStatus(StatusType.Action, "Always show vertices is " + (General.Settings.AlwaysShowVertices ? "ENABLED" : "DISABLED"));
+
+			// Redraw display to show changes
+			RedrawDisplay();
+		}
 
 		// Action to toggle snap to grid
 		[BeginAction("togglesnap")]

--- a/Source/Core/Windows/PreferencesForm.Designer.cs
+++ b/Source/Core/Windows/PreferencesForm.Designer.cs
@@ -401,10 +401,12 @@ namespace CodeImp.DoomBuilder.Windows
 			this.vertexScale.LargeChange = 1;
 			this.vertexScale.Location = new System.Drawing.Point(127, 119);
 			this.vertexScale.Minimum = 1;
+			this.vertexScale.Maximum = 40;
 			this.vertexScale.Name = "vertexScale";
 			this.vertexScale.Size = new System.Drawing.Size(116, 45);
 			this.vertexScale.TabIndex = 4;
 			this.vertexScale.TickStyle = System.Windows.Forms.TickStyle.TopLeft;
+			this.vertexScale.TickFrequency = 4;
 			this.vertexScale.Value = 1;
 			this.vertexScale.ValueChanged += new System.EventHandler(this.vertexScale_ValueChanged);
 			// 

--- a/Source/Core/Windows/PreferencesForm.Designer.cs
+++ b/Source/Core/Windows/PreferencesForm.Designer.cs
@@ -66,6 +66,7 @@ namespace CodeImp.DoomBuilder.Windows
 			this.label26 = new System.Windows.Forms.Label();
 			this.label31 = new System.Windows.Forms.Label();
 			this.cbMarkExtraFloors = new System.Windows.Forms.CheckBox();
+			this.cbFlatShadeVertices = new System.Windows.Forms.CheckBox();
 			this.label32 = new System.Windows.Forms.Label();
 			this.label30 = new System.Windows.Forms.Label();
 			this.cbOldHighlightMode = new System.Windows.Forms.CheckBox();
@@ -285,7 +286,7 @@ namespace CodeImp.DoomBuilder.Windows
 			groupBox1.Controls.Add(this.defaultviewmode);
 			groupBox1.Location = new System.Drawing.Point(8, 8);
 			groupBox1.Name = "groupBox1";
-			groupBox1.Size = new System.Drawing.Size(331, 438);
+			groupBox1.Size = new System.Drawing.Size(331, 462);
 			groupBox1.TabIndex = 0;
 			groupBox1.TabStop = false;
 			groupBox1.Text = " Options ";
@@ -636,6 +637,17 @@ namespace CodeImp.DoomBuilder.Windows
         " color.");
 			this.cbMarkExtraFloors.UseVisualStyleBackColor = true;
 			// 
+			// cbFlatShadeVertices
+			// 
+			this.cbFlatShadeVertices.AutoSize = true;
+			this.cbFlatShadeVertices.Location = new System.Drawing.Point(18, 489);
+			this.cbFlatShadeVertices.Name = "cbFlatShadeVertices";
+			this.cbFlatShadeVertices.Size = new System.Drawing.Size(175, 17);
+			this.cbFlatShadeVertices.TabIndex = 1;
+			this.cbFlatShadeVertices.Text = "Flat shade vertices";
+			this.toolTip1.SetToolTip(this.cbFlatShadeVertices, "When enabled, vertices in classic mode will be drawn with flat shading instead of a raised border.");
+			this.cbFlatShadeVertices.UseVisualStyleBackColor = true;
+			// 
 			// label32
 			// 
 			this.label32.AutoSize = true;
@@ -712,7 +724,7 @@ namespace CodeImp.DoomBuilder.Windows
 			// apply
 			// 
 			this.apply.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.apply.Location = new System.Drawing.Point(467, 548);
+			this.apply.Location = new System.Drawing.Point(467, 573);
 			this.apply.Name = "apply";
 			this.apply.Size = new System.Drawing.Size(112, 25);
 			this.apply.TabIndex = 0;
@@ -724,7 +736,7 @@ namespace CodeImp.DoomBuilder.Windows
 			// 
 			this.cancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
 			this.cancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-			this.cancel.Location = new System.Drawing.Point(585, 548);
+			this.cancel.Location = new System.Drawing.Point(585, 573);
 			this.cancel.Name = "cancel";
 			this.cancel.Size = new System.Drawing.Size(112, 25);
 			this.cancel.TabIndex = 1;
@@ -747,7 +759,7 @@ namespace CodeImp.DoomBuilder.Windows
 			this.tabs.Name = "tabs";
 			this.tabs.Padding = new System.Drawing.Point(24, 3);
 			this.tabs.SelectedIndex = 0;
-			this.tabs.Size = new System.Drawing.Size(688, 527);
+			this.tabs.Size = new System.Drawing.Size(688, 552);
 			this.tabs.TabIndex = 0;
 			this.tabs.SelectedIndexChanged += new System.EventHandler(this.tabs_SelectedIndexChanged);
 			// 
@@ -1203,7 +1215,7 @@ namespace CodeImp.DoomBuilder.Windows
 			this.fieldofviewlabel.Name = "fieldofviewlabel";
 			this.fieldofviewlabel.Size = new System.Drawing.Size(23, 13);
 			this.fieldofviewlabel.TabIndex = 19;
-			this.fieldofviewlabel.Text = "50°";
+			this.fieldofviewlabel.Text = "50Â°";
 			// 
 			// label4
 			// 
@@ -1428,6 +1440,7 @@ namespace CodeImp.DoomBuilder.Windows
 			this.appearancegroup1.Controls.Add(this.activethingsalphalabel);
 			this.appearancegroup1.Controls.Add(this.label31);
 			this.appearancegroup1.Controls.Add(this.cbMarkExtraFloors);
+			this.appearancegroup1.Controls.Add(this.cbFlatShadeVertices);
 			this.appearancegroup1.Controls.Add(this.activethingsalpha);
 			this.appearancegroup1.Controls.Add(this.hiddenthingsalphalabel);
 			this.appearancegroup1.Controls.Add(this.label32);
@@ -2393,7 +2406,7 @@ namespace CodeImp.DoomBuilder.Windows
 			this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
 			this.CancelButton = this.cancel;
-			this.ClientSize = new System.Drawing.Size(709, 585);
+			this.ClientSize = new System.Drawing.Size(709, 610);
 			this.Controls.Add(this.cancel);
 			this.Controls.Add(this.apply);
 			this.Controls.Add(this.tabs);
@@ -2559,6 +2572,7 @@ namespace CodeImp.DoomBuilder.Windows
 		private CodeImp.DoomBuilder.Controls.ColorControl color3dFloors;
 		private System.Windows.Forms.TextBox actiondescription;
 		private System.Windows.Forms.CheckBox cbMarkExtraFloors;
+		private System.Windows.Forms.CheckBox cbFlatShadeVertices;
 		private CodeImp.DoomBuilder.Controls.TransparentTrackBar recentFiles;
 		private System.Windows.Forms.Label labelRecentFiles;
 		private System.Windows.Forms.Label label25;

--- a/Source/Core/Windows/PreferencesForm.cs
+++ b/Source/Core/Windows/PreferencesForm.cs
@@ -97,6 +97,7 @@ namespace CodeImp.DoomBuilder.Windows
             texturesizesbelow.Checked = General.Settings.TextureSizesBelow;
 			cbShowFPS.Checked = General.Settings.ShowFPS;
 			autolaunchontest.Checked = General.Settings.AutoLaunchOnTest;
+			cbFlatShadeVertices.Checked = General.Settings.FlatShadeVertices;
 
 			//mxd
 			locatetexturegroup.Checked = General.Settings.LocateTextureGroup;
@@ -108,8 +109,8 @@ namespace CodeImp.DoomBuilder.Windows
 			labelDynLightCount.Text = General.Settings.GZMaxDynamicLights.ToString();
 			cbStretchView.Checked = General.Settings.GZStretchView;
 			cbOldHighlightMode.Checked = General.Settings.GZOldHighlightMode;
-			vertexScale.Value = General.Clamp((int)(General.Settings.GZVertexScale2D), vertexScale.Minimum, vertexScale.Maximum);
-			vertexScaleLabel.Text = vertexScale.Value * 100 + "%" + (vertexScale.Value == 1 ? " (default)" : "");
+			vertexScale.Value = General.Clamp((int)(General.Settings.GZVertexScale2D * 4.0), vertexScale.Minimum, vertexScale.Maximum);
+			vertexScaleLabel.Text = vertexScale.Value * 25 + "%" + (vertexScale.Value == 4 ? " (default)" : "");
 			cbMarkExtraFloors.Checked = General.Settings.GZMarkExtraFloors;
 			recentFiles.Value = General.Settings.MaxRecentFiles;
 			screenshotsfolderpath.Text = General.Settings.ScreenshotsPath;
@@ -335,6 +336,7 @@ namespace CodeImp.DoomBuilder.Windows
 			General.Settings.ScreenshotsPath = screenshotsfolderpath.Text.Trim(); //mxd
 			General.Settings.ShowFPS = cbShowFPS.Checked;
 			General.Settings.AutoLaunchOnTest = autolaunchontest.Checked;
+			General.Settings.FlatShadeVertices = cbFlatShadeVertices.Checked;
 
 			// Script settings
 			General.Settings.ScriptFontBold = scriptfontbold.Checked;
@@ -416,7 +418,7 @@ namespace CodeImp.DoomBuilder.Windows
 			General.Settings.FilterAnisotropy = RenderDevice.AF_STEPS[anisotropicfiltering.Value];
 			General.Settings.AntiAliasingSamples = RenderDevice.AA_STEPS[antialiasing.Value];
 			General.Settings.GZStretchView = cbStretchView.Checked;
-			General.Settings.GZVertexScale2D = vertexScale.Value;
+			General.Settings.GZVertexScale2D = (float)vertexScale.Value / 4.0f;
 			General.Settings.GZOldHighlightMode = cbOldHighlightMode.Checked;
 			General.Settings.GZMarkExtraFloors = cbMarkExtraFloors.Checked;
 
@@ -530,7 +532,7 @@ namespace CodeImp.DoomBuilder.Windows
 		//mxd
 		private void vertexScale_ValueChanged(object sender, EventArgs e) 
 		{
-			vertexScaleLabel.Text = (vertexScale.Value * 100) + "%";
+			vertexScaleLabel.Text = (vertexScale.Value * 25) + "%";
 		}
 
 		//mxd

--- a/Source/Plugins/BuilderModes/ClassicModes/DragSectorsMode.cs
+++ b/Source/Plugins/BuilderModes/ClassicModes/DragSectorsMode.cs
@@ -170,7 +170,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 				// Draw the dragged item highlighted
 				// This is important to know, because this item is used
 				// for snapping to the grid and snapping to nearest items
-				renderer.PlotVertex(dragitem, ColorCollection.HIGHLIGHT);
+				renderer.PlotVertex(dragitem, ColorCollection.HIGHLIGHT, false);
 				
 				// Done
 				renderer.Finish();

--- a/Source/Plugins/BuilderModes/ClassicModes/DragVerticesMode.cs
+++ b/Source/Plugins/BuilderModes/ClassicModes/DragVerticesMode.cs
@@ -48,7 +48,12 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		#endregion
 
 		#region ================== Properties
-		
+
+		public override bool AlwaysShowVertices
+		{
+			get { return true; }
+		}
+
 		#endregion
 
 		#region ================== Constructor / Disposer

--- a/Source/Plugins/BuilderModes/ClassicModes/LinedefsMode.cs
+++ b/Source/Plugins/BuilderModes/ClassicModes/LinedefsMode.cs
@@ -77,7 +77,9 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		#region ================== Properties
 
 		public override object HighlightedObject { get { return highlighted; } }
-		
+
+		public override bool AlwaysShowVertices { get { return true; } }
+
 		#endregion
 
 		#region ================== Constructor / Disposer

--- a/Source/Plugins/BuilderModes/ClassicModes/VerticesMode.cs
+++ b/Source/Plugins/BuilderModes/ClassicModes/VerticesMode.cs
@@ -66,6 +66,8 @@ namespace CodeImp.DoomBuilder.BuilderModes
 
 		public override object HighlightedObject { get { return highlighted; } }
 
+		public override bool AlwaysShowVertices { get { return true;  } }
+
 		#endregion
 
 		#region ================== Constructor / Disposer

--- a/Source/Plugins/NodesViewer/NodesViewerMode.cs
+++ b/Source/Plugins/NodesViewer/NodesViewerMode.cs
@@ -51,6 +51,8 @@ namespace CodeImp.DoomBuilder.Plugins.NodesViewer
 		public Vector2D[] Vertices { get { return verts; } }
 		public Subsector[] Subsectors { get { return ssectors; } }
 		public NodesForm Form { get { return form; } }
+		
+		public override bool AlwaysShowVertices { get { return true;  } }
 
 		#endregion
 


### PR DESCRIPTION
This PR provides a few extended options for rendering vertices:

* A new bindable action (also an item in the View menu): "Always show vertices". When turned on (the default), this mimics the current behaviour and unconditionally renders vertices in the 2D viewport. When turned off, only classic editor modes that override AlwaysShowVertices and return true will be able to draw vertices (unless an additional parameter is passed to the PlotVertex function to force it). The following modes will always draw vertices regardless of this setting: Vertex mode, Linedef mode, Node Viewer mode.
* A new option in the Appearance tab of the Preferences pane: "Flat shade vertices". When enabled, vertices will be drawn as a solid colored square instead of having the raised border effect.
* Vertex scale can now go down to 25% (previous minimum was 100%).