### PR TITLE
Search the user's PATH to find the bash binary

### DIFF
--- a/builder.sh
+++ b/builder.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 mono Builder.exe


### PR DESCRIPTION
Use `#!/usr/bin/env bash` instead of `#!/bin/bash`
 * The former searches the user's PATH to find the bash binary.
 * The latter assumes it is always installed to /bin/ which can cause issues on distros like NixOS