### PR TITLE
Fix error when saving loaded map on Linux

### DIFF
--- a/Source/Core/General/FileLockChecker.cs
+++ b/Source/Core/General/FileLockChecker.cs
@@ -88,8 +88,14 @@ namespace CodeImp.DoomBuilder
 		/// </remarks>
 		static public FileLockCheckResult CheckFile(string path)
 		{
+			//File locks are extremely rare on Linux, and using methods below to check cause a crash. Should be safe to assume it's not being written to.
+			if (Environment.OSVersion.Platform == PlatformID.Unix)
+			{
+				return new FileLockCheckResult { Error = "" };
+			}
+			
 			//mxd. Do it the clunky way? (WinXP)
-			if(Environment.OSVersion.Version.Major < 6)
+			if(Environment.OSVersion.Platform == PlatformID.Unix && Environment.OSVersion.Version.Major < 6)
 			{
 				bool locked = false;
 				

--- a/Source/Core/General/FileLockChecker.cs
+++ b/Source/Core/General/FileLockChecker.cs
@@ -88,14 +88,8 @@ namespace CodeImp.DoomBuilder
 		/// </remarks>
 		static public FileLockCheckResult CheckFile(string path)
 		{
-			//File locks are extremely rare on Linux, and using methods below to check cause a crash. Should be safe to assume it's not being written to.
-			if (Environment.OSVersion.Platform == PlatformID.Unix)
-			{
-				return new FileLockCheckResult { Error = "" };
-			}
-			
-			//mxd. Do it the clunky way? (WinXP)
-			if(Environment.OSVersion.Platform == PlatformID.Unix && Environment.OSVersion.Version.Major < 6)
+			//Fallback to traditional checking on Linux or WinXP
+			if(Environment.OSVersion.Platform == PlatformID.Unix || Environment.OSVersion.Version.Major < 6)
 			{
 				bool locked = false;
 				
@@ -105,8 +99,7 @@ namespace CodeImp.DoomBuilder
 				}
 				catch(IOException e)
 				{
-					int errorcode = Marshal.GetHRForException(e) & ((1 << 16) - 1);
-					locked = (errorcode == 32 || errorcode == 33);
+					locked = true;
 				}
 
 				return new FileLockCheckResult { Error = (locked ? "Unable to save the map. Map file is locked by another process." : string.Empty) };

--- a/builder.sh
+++ b/builder.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-mono Builder.exe
+mono $(dirname $0)Builder.exe


### PR DESCRIPTION
When loading a map and attempting to re-save on Linux, UDB would attempt to check if the file was locked before writing, by using a windows system library. There exists a fallback in `FileLockChecker.cs` for Windows XP, and this PR slightly modifies this code and uses it for Linux as well. I haven't actually tested it when the file is locked, as locking files on Linux is very rare and slightly unconventional, but it prevents UDB from crashing outright (and not writing anything) when attempting to save.