### PR TITLE
Centralize API calls and add mock calls on NO_WIN32 platforms

### DIFF
--- a/Source/Core/Builder.csproj
+++ b/Source/Core/Builder.csproj
@@ -242,6 +242,7 @@
     <Compile Include="Dehacked\DehackedParser.cs" />
     <Compile Include="Dehacked\DehackedThing.cs" />
     <Compile Include="General\SHA256Hash.cs" />
+    <Compile Include="General\SysCall.cs" />
     <Compile Include="General\ToastManager.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/Source/Core/BuilderMono.csproj
+++ b/Source/Core/BuilderMono.csproj
@@ -650,6 +650,7 @@
     <Compile Include="ZDoom\ZScriptStateGoto.cs" />
     <Compile Include="ZDoom\ZScriptStateStructure.cs" />
     <Compile Include="ZDoom\ZScriptTokenizer.cs" />
+    <Compile Include="General\SysCall.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="JetBrains.Profiler.Core.Api, Version=1.3.1661.20096, Culture=neutral, PublicKeyToken=1010a0d8d6380325" Condition=" '$(Configuration)|$(Platform)' == 'Debug + Profiler|x86' Or '$(Configuration)|$(Platform)' == 'Release + Profiler|x86' ">

--- a/Source/Core/Controls/ArgumentsControl.cs
+++ b/Source/Core/Controls/ArgumentsControl.cs
@@ -3,7 +3,6 @@
 using System;
 using System.ComponentModel;
 using System.Drawing;
-using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using CodeImp.DoomBuilder.Config;
 using CodeImp.DoomBuilder.GZBuilder.Data;
@@ -19,9 +18,6 @@ namespace CodeImp.DoomBuilder.Controls
 	public partial class ArgumentsControl : UserControl
 	{
 		#region ================== Native stuff
-
-		[DllImport("user32.dll")]
-		private static extern int SendMessage(IntPtr hWnd, Int32 wMsg, bool wParam, Int32 lParam);
 		
 		private const int WM_SETREDRAW = 11;
 
@@ -497,12 +493,12 @@ namespace CodeImp.DoomBuilder.Controls
 
 		private void BeginUpdate()
 		{
-			SendMessage(this.Parent.Handle, WM_SETREDRAW, false, 0);
+            SysCall.SendMessage(this.Parent.Handle, WM_SETREDRAW, false, 0);
 		}
 
 		private void EndUpdate()
 		{
-			SendMessage(this.Parent.Handle, WM_SETREDRAW, true, 0);
+            SysCall.SendMessage(this.Parent.Handle, WM_SETREDRAW, true, 0);
 			this.Parent.Refresh();
 		}
 

--- a/Source/Core/Controls/BufferedTreeView.cs
+++ b/Source/Core/Controls/BufferedTreeView.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Windows.Forms;
-using System.Runtime.InteropServices;
 
 // As per http://stackoverflow.com/questions/10362988/treeview-flickering
 // Gets rid of the flickering default TreeView
@@ -14,13 +13,10 @@ namespace CodeImp.DoomBuilder.Controls
 		//private const int TVM_GETEXTENDEDSTYLE = 0x1100 + 45;
 		private const int TVS_EX_DOUBLEBUFFER = 0x0004;
 
-		[DllImport("user32.dll")]
-		private static extern IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr wp, IntPtr lp);
-		
 		// Methods
 		protected override void OnHandleCreated(EventArgs e)
 		{
-			SendMessage(this.Handle, TVM_SETEXTENDEDSTYLE, (IntPtr)TVS_EX_DOUBLEBUFFER, (IntPtr)TVS_EX_DOUBLEBUFFER);
+			SysCall.SendMessage(this.Handle, TVM_SETEXTENDEDSTYLE, (IntPtr)TVS_EX_DOUBLEBUFFER, (IntPtr)TVS_EX_DOUBLEBUFFER);
 			base.OnHandleCreated(e);
 		}
 	}

--- a/Source/Core/Controls/FieldsEditorControl.cs
+++ b/Source/Core/Controls/FieldsEditorControl.cs
@@ -602,7 +602,7 @@ namespace CodeImp.DoomBuilder.Controls
 						enumscombo.Location = new Point(cellrect.Left, cellrect.Top);
 						enumscombo.Width = cellrect.Width;
 						int internalheight = cellrect.Height - (enumscombo.Height - enumscombo.ClientRectangle.Height) - 6;
-						General.SetComboBoxItemHeight(enumscombo, internalheight);
+                        SysCall.SetComboBoxItemHeight(enumscombo, internalheight);
 						
 						// Select the value of this field (for DropDownList style combo)
 						foreach(EnumItem i in enumscombo.Items)

--- a/Source/Core/Controls/OptimizedListView.cs
+++ b/Source/Core/Controls/OptimizedListView.cs
@@ -27,16 +27,27 @@ namespace CodeImp.DoomBuilder.Controls
 {
 	public class OptimizedListView : ListView
 	{
-		#region ================== API Declarations
+        #region ================== API Declarations
 
-		[DllImport("user32.dll")]
+#if NO_WIN32
+
+        private static int SendMessage(IntPtr window, int message, int wParam, ref LVGROUP lParam)
+        {
+            return 0;
+        }
+
+#else
+
+        [DllImport("user32.dll")]
 		private static extern int SendMessage(IntPtr window, int message, int wParam, ref LVGROUP lParam);
 
-		#endregion
+#endif
 
-		#region ================== Structs
+        #endregion
 
-		[StructLayout(LayoutKind.Sequential)]
+        #region ================== Structs
+
+        [StructLayout(LayoutKind.Sequential)]
 		private struct LVGROUP
 		{
 			public int cbSize;
@@ -53,9 +64,9 @@ namespace CodeImp.DoomBuilder.Controls
 			public int uAlign;
 		}
 
-		#endregion
+#endregion
 
-		#region ================== Enums
+#region ================== Enums
 
 		[Flags]
 		private enum GroupState
@@ -65,16 +76,16 @@ namespace CodeImp.DoomBuilder.Controls
 			EXPANDED = 0
 		}
 
-		#endregion
+#endregion
 
-		#region ================== Delegates
+#region ================== Delegates
 
 		private delegate bool CallBackSetGroupCollapsible(ListViewGroup group, bool collapsed);
 		private delegate bool CallBackGetGroupCollapsed(ListViewGroup group);
 
-		#endregion
+#endregion
 
-		#region ================== Constructor
+#region ================== Constructor
 
 		// Constructor
 		public OptimizedListView()
@@ -83,9 +94,9 @@ namespace CodeImp.DoomBuilder.Controls
 			SetStyle(ControlStyles.OptimizedDoubleBuffer, true);
 		}
 
-		#endregion
+#endregion
 
-		#region ================== Methods
+#region ================== Methods
 
 		//mxd. Collapsible groups support. Created using http://www.codeproject.com/Articles/31276/Add-Group-Collapse-Behavior-on-a-Listview-Control as a reference
 		public bool SetGroupCollapsed(ListViewGroup group, bool collapsed) 
@@ -154,6 +165,6 @@ namespace CodeImp.DoomBuilder.Controls
 			}
 		}
 
-		#endregion
+#endregion
 	}
 }

--- a/Source/Core/Controls/PlaceholderToolStripTextBox.cs
+++ b/Source/Core/Controls/PlaceholderToolStripTextBox.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Drawing;
-using System.Runtime.InteropServices;
 using System.Windows.Forms;
 
 #endregion
@@ -13,13 +12,6 @@ namespace CodeImp.DoomBuilder.Controls
 	[ToolboxBitmap(typeof(ToolStripTextBox))]
 	public class PlaceholderToolStripTextBox : ToolStripTextBox
 	{
-		#region ================== DLL Imports
-
-		[DllImport("user32.dll", CharSet = CharSet.Auto)]
-		private static extern int SendMessage(IntPtr hWnd, int msg, int wParam, string lParam);
-
-		#endregion
-
 		#region ================== Constants
 
 		private const int EM_SETCUEBANNER = 0x1501;
@@ -70,7 +62,7 @@ namespace CodeImp.DoomBuilder.Controls
 		private void UpdatePlaceholderText()
 		{
 			#if !MONO_WINFORMS
-			SendMessage(Control.Handle, EM_SETCUEBANNER, 0, placeholder);
+			SysCall.SendMessage(Control.Handle, EM_SETCUEBANNER, 0, placeholder);
 			#endif
 		}
 

--- a/Source/Core/Controls/Scripting/ScriptEditorPanel.cs
+++ b/Source/Core/Controls/Scripting/ScriptEditorPanel.cs
@@ -358,7 +358,7 @@ namespace CodeImp.DoomBuilder.Controls
 			}
 			else
 			{
-				General.MessageBeep(MessageBeepType.Default);
+                SysCall.MessageBeep(MessageBeepType.Default);
 				return false;
 			}
 		}
@@ -386,7 +386,7 @@ namespace CodeImp.DoomBuilder.Controls
 			} 
 			else 
 			{
-				General.MessageBeep(MessageBeepType.Default);
+                SysCall.MessageBeep(MessageBeepType.Default);
 				return false;
 			}
 		}
@@ -962,11 +962,11 @@ namespace CodeImp.DoomBuilder.Controls
 				else if(t.Config.Compiler != null) //mxd
 					buttoncompile_Click(this, EventArgs.Empty);
 				else
-					General.MessageBeep(MessageBeepType.Default);
+                    SysCall.MessageBeep(MessageBeepType.Default);
 			}
 			else
 			{
-				General.MessageBeep(MessageBeepType.Default);
+                SysCall.MessageBeep(MessageBeepType.Default);
 			}
 		}
 		
@@ -1007,7 +1007,7 @@ namespace CodeImp.DoomBuilder.Controls
 				case ScriptStatusType.Warning:
 					if(!newstatus.displayed)
 					{
-						General.MessageBeep(MessageBeepType.Warning);
+						SysCall.MessageBeep(MessageBeepType.Warning);
 						statusflasher.Interval = MainForm.WARNING_FLASH_INTERVAL;
 						statusflashcount = MainForm.WARNING_FLASH_COUNT;
 						statusflasher.Start();
@@ -1466,12 +1466,12 @@ namespace CodeImp.DoomBuilder.Controls
 
 		private void searchnext_Click(object sender, EventArgs e)
 		{
-			if(!ActiveTab.FindNext(GetQuickSearchOptions(), false)) General.MessageBeep(MessageBeepType.Default);
+			if(!ActiveTab.FindNext(GetQuickSearchOptions(), false)) SysCall.MessageBeep(MessageBeepType.Default);
 		}
 
 		private void searchprev_Click(object sender, EventArgs e) 
 		{
-			if(!ActiveTab.FindPrevious(GetQuickSearchOptions())) General.MessageBeep(MessageBeepType.Default);
+			if(!ActiveTab.FindPrevious(GetQuickSearchOptions())) SysCall.MessageBeep(MessageBeepType.Default);
 		}
 
 		// This flashes the status icon

--- a/Source/Core/Data/DataManager.cs
+++ b/Source/Core/Data/DataManager.cs
@@ -23,7 +23,6 @@ using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Windows.Forms;
 using CodeImp.DoomBuilder.Config;

--- a/Source/Core/Data/ImageData.cs
+++ b/Source/Core/Data/ImageData.cs
@@ -24,7 +24,6 @@ using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using CodeImp.DoomBuilder.Geometry;
 using CodeImp.DoomBuilder.IO;
 using CodeImp.DoomBuilder.Rendering;

--- a/Source/Core/Data/SpriteImage.cs
+++ b/Source/Core/Data/SpriteImage.cs
@@ -19,7 +19,6 @@
 using System;
 using System.Drawing;
 using System.IO;
-using System.Runtime.InteropServices;
 using CodeImp.DoomBuilder.IO;
 using CodeImp.DoomBuilder.Windows;
 

--- a/Source/Core/Data/TEXTURESImage.cs
+++ b/Source/Core/Data/TEXTURESImage.cs
@@ -125,7 +125,7 @@ namespace CodeImp.DoomBuilder.Data
 				bitmap = new Bitmap(width, height, PixelFormat.Format32bppArgb);
 				BitmapData bitmapdata = bitmap.LockBits(new Rectangle(0, 0, width, height), ImageLockMode.WriteOnly, PixelFormat.Format32bppArgb);
 				PixelColor* pixels = (PixelColor*)bitmapdata.Scan0.ToPointer();
-				General.ZeroPixels(pixels, width * height);
+                SysCall.ZeroPixels(pixels, width * height);
 				bitmap.UnlockBits(bitmapdata);
 				g = Graphics.FromImage(bitmap);
 			}

--- a/Source/Core/Data/TextureImage.cs
+++ b/Source/Core/Data/TextureImage.cs
@@ -95,7 +95,7 @@ namespace CodeImp.DoomBuilder.Data
 				bitmap = new Bitmap(width, height, PixelFormat.Format32bppArgb);
 				bitmapdata = bitmap.LockBits(new Rectangle(0, 0, width, height), ImageLockMode.WriteOnly, PixelFormat.Format32bppArgb);
 				pixels = (PixelColor*)bitmapdata.Scan0.ToPointer();
-				General.ZeroPixels(pixels, width * height);
+                SysCall.ZeroPixels(pixels, width * height);
 			}
 			catch(Exception e)
 			{

--- a/Source/Core/Data/VoxelImage.cs
+++ b/Source/Core/Data/VoxelImage.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Text;
 using CodeImp.DoomBuilder.Rendering;
 using CodeImp.DoomBuilder.Windows;

--- a/Source/Core/Editing/CopyPasteManager.cs
+++ b/Source/Core/Editing/CopyPasteManager.cs
@@ -1,4 +1,4 @@
-
+﻿
 #region ================== Copyright (c) 2007 Pascal vd Heiden
 
 /*
@@ -288,7 +288,7 @@ namespace CodeImp.DoomBuilder.Editing
 			else
 			{
 				// Copy not allowed
-				General.MessageBeep(MessageBeepType.Warning);
+				SysCall.MessageBeep(MessageBeepType.Warning);
 			}
 			
 			// Aborted
@@ -410,14 +410,14 @@ namespace CodeImp.DoomBuilder.Editing
                     //      note that this is a hack and probably needs to be fixed properly by making it beep elsewhere so that the current active mode can decide this.
                     if (!(General.Editing.Mode is VisualMode))
                     {
-                        General.MessageBeep(MessageBeepType.Warning);
+                        SysCall.MessageBeep(MessageBeepType.Warning);
                     }
                 }
 			}
 			else
 			{
 				// Paste not allowed
-				General.MessageBeep(MessageBeepType.Warning);
+				SysCall.MessageBeep(MessageBeepType.Warning);
 			}
 		}
 		
@@ -470,7 +470,7 @@ namespace CodeImp.DoomBuilder.Editing
 			else
 			{
 				// Paste not allowed
-				General.MessageBeep(MessageBeepType.Warning);
+				SysCall.MessageBeep(MessageBeepType.Warning);
 			}
 		}
 		
@@ -524,7 +524,7 @@ namespace CodeImp.DoomBuilder.Editing
 				else
 				{
 					// Can't make a prefab right now
-					General.MessageBeep(MessageBeepType.Warning);
+					SysCall.MessageBeep(MessageBeepType.Warning);
 				}
 				
 				// Done
@@ -534,7 +534,7 @@ namespace CodeImp.DoomBuilder.Editing
 			else
 			{
 				// Create prefab not allowed
-				General.MessageBeep(MessageBeepType.Warning);
+				SysCall.MessageBeep(MessageBeepType.Warning);
 			}
 		}
 		
@@ -598,7 +598,7 @@ namespace CodeImp.DoomBuilder.Editing
 			else
 			{
 				// Insert not allowed
-				General.MessageBeep(MessageBeepType.Warning);
+				SysCall.MessageBeep(MessageBeepType.Warning);
 			}
 		}
 		
@@ -654,20 +654,20 @@ namespace CodeImp.DoomBuilder.Editing
 					}
 					else
 					{
-						General.MessageBeep(MessageBeepType.Warning);
+						SysCall.MessageBeep(MessageBeepType.Warning);
 						lastprefabfile = null;
 						General.MainWindow.UpdateInterface();
 					}
 				}
 				else
 				{
-					General.MessageBeep(MessageBeepType.Warning);
+					SysCall.MessageBeep(MessageBeepType.Warning);
 				}
 			}
 			else
 			{
 				// Insert not allowed
-				General.MessageBeep(MessageBeepType.Warning);
+				SysCall.MessageBeep(MessageBeepType.Warning);
 			}
 		}
 		

--- a/Source/Core/General/SysCall.cs
+++ b/Source/Core/General/SysCall.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Windows.Forms;
+using CodeImp.DoomBuilder.Rendering;
+using CodeImp.DoomBuilder.Windows;
+
+namespace CodeImp.DoomBuilder
+{
+    public static class SysCall
+    {
+
+#if NO_WIN32
+
+        internal static void InvokeUIActions(MainForm mainform)
+        {
+            // This implementation really should work universally, but it seemed to hang sometimes on Windows.
+            // Let's hope the mono implementation of Winforms works better.
+            mainform.Invoke(new System.Action(() => { mainform.ProcessQueuedUIActions(); }));
+        }
+
+        internal static bool MessageBeep(MessageBeepType type)
+        {
+            System.Media.SystemSounds.Beep.Play();
+            return true;
+        }
+
+        internal static bool LockWindowUpdate(IntPtr hwnd)
+        {
+            // This can be safely ignored. It is a performance/flicker optimization. It might not even be needed on Windows anymore.
+            return true;
+        }
+
+        internal unsafe static void ZeroPixels(PixelColor* pixels, int size)
+        {
+            var transparent = new PixelColor(0, 0, 0, 0);
+            for (int i = 0; i < size; i++)
+                pixels[i] = transparent;
+        }
+
+        internal static int SendMessage(IntPtr hWnd, Int32 wMsg, bool wParam, Int32 lParam)
+        {
+            return 0;
+        }
+
+        internal static IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr wp, IntPtr lp)
+        {
+            return IntPtr.Zero;
+        }
+
+        internal static int SendMessage(IntPtr hWnd, int msg, int wParam, string lParam)
+        {
+            return 0;
+        }
+
+        internal static void SetComboBoxItemHeight(ComboBox combobox, int height)
+        {
+            // Only used by FieldsEditorControl. Not sure what its purpose is, might only be visual adjustment that isn't strictly needed?
+        }
+
+        public static int GetWindowLong(IntPtr hWnd, int nIndex)
+        {
+            return 0;
+        }
+
+#else
+
+        [DllImport("user32.dll")]
+        internal static extern bool LockWindowUpdate(IntPtr hwnd);
+
+        [DllImport("kernel32.dll", EntryPoint = "RtlZeroMemory", SetLastError = false)]
+        static extern void ZeroMemory(IntPtr dest, int size);
+
+        internal unsafe static void ZeroPixels(PixelColor* pixels, int size) { ZeroMemory(new IntPtr(pixels), size * sizeof(PixelColor)); }
+
+        [DllImport("user32.dll", EntryPoint = "SendMessage", SetLastError = true, CallingConvention = CallingConvention.StdCall)]
+        internal static extern int SendMessage(IntPtr hWnd, Int32 wMsg, bool wParam, Int32 lParam);
+
+        [DllImport("user32.dll")]
+        internal static extern IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr wp, IntPtr lp);
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto)]
+        internal static extern int SendMessage(IntPtr hWnd, int msg, int wParam, string lParam);
+
+        internal static void SetComboBoxItemHeight(ComboBox combobox, int height)
+        {
+            SendMessage(combobox.Handle, General.CB_SETITEMHEIGHT, new IntPtr(-1), new IntPtr(height));
+        }
+
+        [DllImport("user32.dll", EntryPoint = "PostMessage", SetLastError = true, CallingConvention = CallingConvention.StdCall)]
+        static extern int PostMessage(IntPtr hwnd, uint Msg, IntPtr wParam, IntPtr lParam);
+
+        internal static void InvokeUIActions(MainForm mainform)
+        {
+            PostMessage(mainform.Handle, General.WM_UIACTION, IntPtr.Zero, IntPtr.Zero);
+        }
+
+        [DllImport("user32.dll", SetLastError = true)]
+        internal static extern bool MessageBeep(MessageBeepType type);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        internal static extern uint GetShortPathName([MarshalAs(UnmanagedType.LPTStr)] string longpath, [MarshalAs(UnmanagedType.LPTStr)]StringBuilder shortpath, uint buffersize);
+
+        [DllImport("user32.dll")]
+        public static extern int GetWindowLong(IntPtr hWnd, int nIndex);
+
+#endif
+
+    }
+}

--- a/Source/Core/General/ToastManager.cs
+++ b/Source/Core/General/ToastManager.cs
@@ -435,9 +435,9 @@ namespace CodeImp.DoomBuilder
 
 			// Play a sound for warnings and errors
 			if (type == ToastType.WARNING)
-				General.MessageBeep(MessageBeepType.Warning);
+				SysCall.MessageBeep(MessageBeepType.Warning);
 			else if (type == ToastType.ERROR)
-				General.MessageBeep(MessageBeepType.Error);
+				SysCall.MessageBeep(MessageBeepType.Error);
 		}
 
 		#endregion

--- a/Source/Core/Windows/MainForm.cs
+++ b/Source/Core/Windows/MainForm.cs
@@ -1,4 +1,4 @@
-
+﻿
 #region ================== Copyright (c) 2007 Pascal vd Heiden
 
 /*
@@ -336,7 +336,7 @@ namespace CodeImp.DoomBuilder.Windows
 		// This makes a beep sound
 		public void MessageBeep(MessageBeepType type)
 		{
-			General.MessageBeep(type);
+			SysCall.MessageBeep(type);
 		}
 
 		// This sets up the interface
@@ -493,14 +493,14 @@ namespace CodeImp.DoomBuilder.Windows
 		internal void LockUpdate()
 		{
 			lockupdatecount++;
-			if(lockupdatecount == 1) General.LockWindowUpdate(this.Handle);
+			if(lockupdatecount == 1) SysCall.LockWindowUpdate(this.Handle);
 		}
 
 		// This unlocks for updating
 		internal void UnlockUpdate()
 		{
 			lockupdatecount--;
-			if(lockupdatecount == 0) General.LockWindowUpdate(IntPtr.Zero);
+			if(lockupdatecount == 0) SysCall.LockWindowUpdate(IntPtr.Zero);
 			if(lockupdatecount < 0) lockupdatecount = 0;
 		}
 
@@ -4452,7 +4452,7 @@ namespace CodeImp.DoomBuilder.Windows
                 }
 
                 if (notify)
-                    General.InvokeUIActions(this);
+                    SysCall.InvokeUIActions(this);
             }
         }
 

--- a/Source/Plugins/BuilderModes/General/BuilderPlug.cs
+++ b/Source/Plugins/BuilderModes/General/BuilderPlug.cs
@@ -21,7 +21,6 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Reflection;
-using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using CodeImp.DoomBuilder.Actions;
 using CodeImp.DoomBuilder.BuilderModes.Interface;
@@ -48,16 +47,9 @@ namespace CodeImp.DoomBuilder.BuilderModes
 	}
 
 	public class BuilderPlug : Plug
-	{
-		#region ================== API Declarations
-
-		[DllImport("user32.dll")]
-		internal static extern int GetWindowLong(IntPtr hWnd, int nIndex);
-		
-		#endregion
-		
+	{		
 		#region ================== Constants
-
+        
 		internal const int WS_HSCROLL = 0x100000;
 		internal const int WS_VSCROLL = 0x200000;
 		internal const int GWL_STYLE = -16;

--- a/Source/Plugins/BuilderModes/Interface/UndoRedoPanel.cs
+++ b/Source/Plugins/BuilderModes/Interface/UndoRedoPanel.cs
@@ -193,7 +193,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		private void UpdateColumnSizes()
 		{
 			// Check if a vertical scrollbar exists and adjust the column in the listbox accordingly
-			if((BuilderPlug.GetWindowLong(list.Handle, BuilderPlug.GWL_STYLE) & BuilderPlug.WS_VSCROLL) != 0)
+			if((SysCall.GetWindowLong(list.Handle, BuilderPlug.GWL_STYLE) & BuilderPlug.WS_VSCROLL) != 0)
 				coldescription.Width = list.ClientRectangle.Width - 2;
 			else
 				coldescription.Width = list.ClientRectangle.Width - SystemInformation.VerticalScrollBarWidth - 2;


### PR DESCRIPTION
All user32 and kernel32 API calls, except one in "OptimizedListView.cs", are now inside a new "SysCall" static class, making it a lot easier to manage.
Also, mock calls were created to prevent crashes related to missing DLLs on Linux.

Build tested on:
- Windows 10 LTSC 2021
- Fedora 37
- Ubuntu 20.04

Related issue: https://github.com/jewalky/UltimateDoomBuilder/issues/816