### PR TITLE
Update selection info when selecting sectors outline

### DIFF
--- a/Source/Plugins/StairSectorBuilder/BuilderPlug.cs
+++ b/Source/Plugins/StairSectorBuilder/BuilderPlug.cs
@@ -164,6 +164,7 @@ namespace CodeImp.DoomBuilder.StairSectorBuilderMode
 				}
 			}
 
+			General.Editing.Mode.UpdateSelectionInfo();
 			General.Interface.RedrawDisplay();
 		}
 


### PR DESCRIPTION
Using the "Select Sectors Outline" action didn't actually update the selection info, causing some small bugs like selection numbers appearing over linedefs that are not selected anymore. This tiny change fixes that.