### PR TITLE
Check for unix instead of linux in file locker

### DIFF
--- a/Source/Core/General/FileLockChecker.cs
+++ b/Source/Core/General/FileLockChecker.cs
@@ -88,8 +88,8 @@ namespace CodeImp.DoomBuilder
 		/// </remarks>
 		static public FileLockCheckResult CheckFile(string path)
 		{
-			//mxd. Do it the clunky way? (WinXP)
-			if(Environment.OSVersion.Version.Major < 6 || RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+			//mxd. Do it the clunky way? (non-Windows)
+			if(Environment.OSVersion.Platform == PlatformID.Unix)
 			{
 				bool locked = false;
 				


### PR DESCRIPTION
The calls to native windows functions wouldn't be valid on any unix os so expand the check.

The check for Windows XP is removed as that platform is not supported anymore.