### PR TITLE
 Add Tab to the list of special input controls

### DIFF
--- a/Source/Core/Windows/PreferencesForm.cs
+++ b/Source/Core/Windows/PreferencesForm.cs
@@ -633,8 +633,10 @@ namespace CodeImp.DoomBuilder.Windows
 		private void FillControlsList(Action a)
 		{
 			actioncontrol.Items.Clear();
-			
+
 			// Fill combobox with special controls
+			actioncontrol.Items.Add(new KeyControl(Keys.Tab, "Tab"));
+
 			if(a.AllowMouse)
 			{
 				actioncontrol.Items.Add(new KeyControl(Keys.LButton, "LButton"));


### PR DESCRIPTION
By default, Tab is bound to "Toggle Enhanced Rendering Effects". However, if it is ever removed, it is not possible to rebind this key from within UDB. Pressing Tab in the key combination textbox will simply shift focus to the action description, so it becomes necessary to delve into config files just to rebind this key.

Adding the Tab key to the list of special input controls should make it much easier to work with.