### PR TITLE
Add actions for moving the selection in Edit Selection mode

### DIFF
--- a/Source/Plugins/BuilderModes/ClassicModes/EditSelectionMode.cs
+++ b/Source/Plugins/BuilderModes/ClassicModes/EditSelectionMode.cs
@@ -2298,6 +2298,54 @@ namespace CodeImp.DoomBuilder.BuilderModes
 			General.Interface.RedrawDisplay();
 		}
 
+		[BeginAction("moveselectionup")]
+		public void MoveSelectionUp()
+		{
+			offset.y += General.Map.Grid.GridSize;
+
+			// Update
+			UpdateGeometry();
+			UpdateRectangleComponents();
+			General.Map.Map.Update();
+			General.Interface.RedrawDisplay();
+		}
+
+		[BeginAction("moveselectiondown")]
+		public void MoveSelectionDown()
+		{
+			offset.y -= General.Map.Grid.GridSize;
+
+			// Update
+			UpdateGeometry();
+			UpdateRectangleComponents();
+			General.Map.Map.Update();
+			General.Interface.RedrawDisplay();
+		}
+
+		[BeginAction("moveselectionleft")]
+		public void MoveSelectionLeft()
+		{
+			offset.x -= General.Map.Grid.GridSize;
+
+			// Update
+			UpdateGeometry();
+			UpdateRectangleComponents();
+			General.Map.Map.Update();
+			General.Interface.RedrawDisplay();
+		}
+
+		[BeginAction("moveselectionright")]
+		public void MoveSelectionRight()
+		{
+			offset.x += General.Map.Grid.GridSize;
+
+			// Update
+			UpdateGeometry();
+			UpdateRectangleComponents();
+			General.Map.Map.Update();
+			General.Interface.RedrawDisplay();
+		}
+
 		#endregion
 	}
 }

--- a/Source/Plugins/BuilderModes/Resources/Actions.cfg
+++ b/Source/Plugins/BuilderModes/Resources/Actions.cfg
@@ -1268,6 +1268,50 @@ flipselectionh
 	allowscroll = true;
 }
 
+moveselectionup
+{
+	title = "Move Selection Up by Grid Size";
+	category = "edit";
+	description = "Moves the selection in Edit Selection mode up by the current grid size.";
+	allowkeys = true;
+	allowmouse = true;
+	allowscroll = true;
+	repeat = true;
+}
+
+moveselectiondown
+{
+	title = "Move Selection Down by Grid Size";
+	category = "edit";
+	description = "Moves the selection in Edit Selection mode down by the current grid size.";
+	allowkeys = true;
+	allowmouse = true;
+	allowscroll = true;
+	repeat = true;
+}
+
+moveselectionleft
+{
+	title = "Move Selection Left by Grid Size";
+	category = "edit";
+	description = "Moves the selection in Edit Selection mode left by the current grid size.";
+	allowkeys = true;
+	allowmouse = true;
+	allowscroll = true;
+	repeat = true;
+}
+
+moveselectionright
+{
+	title = "Move Selection Right by Grid Size";
+	category = "edit";
+	description = "Moves the selection in Edit Selection mode right by the current grid size.";
+	allowkeys = true;
+	allowmouse = true;
+	allowscroll = true;
+	repeat = true;
+}
+
 //mxd
 rotateclockwise
 {


### PR DESCRIPTION
Adds four actions to Edit Selection mode, which will move the selection up/down/left/right by the current grid size.

![moveselection](https://github.com/jewalky/UltimateDoomBuilder/assets/36791160/b38e0917-4048-4ace-b114-1371f619c843)
