### PR TITLE
Curve Linedefs: increment angle by 5 instead of 8 when using rotate actions

### DIFF
--- a/Source/Plugins/BuilderModes/Interface/CurveLinedefsOptionsPanel.Designer.cs
+++ b/Source/Plugins/BuilderModes/Interface/CurveLinedefsOptionsPanel.Designer.cs
@@ -147,7 +147,7 @@
 			// 
 			this.angle.AutoSize = false;
 			this.angle.Increment = new decimal(new int[] {
-            8,
+            5,
             0,
             0,
             0});


### PR DESCRIPTION
This makes the increment step match other angle-related fields.