### PR TITLE
Add line special 301: Line_QuickPortal to ZDoom UDMF

### DIFF
--- a/Build/Configurations/Includes/ZDoom_linedefs.cfg
+++ b/Build/Configurations/Includes/ZDoom_linedefs.cfg
@@ -4449,5 +4449,20 @@ udmf
 	line
 	{
 		121 = NULL;
+
+		301
+		{
+			title = "Line Quick Portal";
+			id = "Line_QuickPortal";
+			requiresactivation = false;
+
+			arg0
+			{
+				title = "Non-interactive";
+				type = 3;
+			}
+			linetolinetag = true;
+			linetolinesameaction = true;
+		}
 	}
 }


### PR DESCRIPTION
This was ported over from Eternity in ZDoom/gzdoom@7e74d1c4a12ff454ad226d2f7393d9f5504277d0

It requires UDMF's line tag support to be useful, so it is added to the `udmf` block rather than the `zdoom` block.