### PR TITLE
Support (counter)clockwise rotation actions in Edit Selection Mode

### DIFF
--- a/Source/Plugins/BuilderModes/ClassicModes/EditSelectionMode.cs
+++ b/Source/Plugins/BuilderModes/ClassicModes/EditSelectionMode.cs
@@ -2346,6 +2346,30 @@ namespace CodeImp.DoomBuilder.BuilderModes
 			General.Interface.RedrawDisplay();
 		}
 
-		#endregion
+		[BeginAction("rotateclockwise")]
+		public void RotateCW()
+		{
+			rotation += Angle2D.DegToRad(5);
+
+			// Update
+			UpdateGeometry();
+			UpdateRectangleComponents();
+			General.Map.Map.Update();
+			General.Interface.RedrawDisplay();
+		}
+
+		[BeginAction("rotatecounterclockwise")]
+		public void RotateCCW()
+		{
+			rotation -= Angle2D.DegToRad(5);
+
+			// Update
+			UpdateGeometry();
+			UpdateRectangleComponents();
+			General.Map.Map.Update();
+			General.Interface.RedrawDisplay();
+		}
+
+			#endregion
 	}
 }

--- a/Source/Plugins/BuilderModes/ClassicModes/EditSelectionMode.cs
+++ b/Source/Plugins/BuilderModes/ClassicModes/EditSelectionMode.cs
@@ -2370,6 +2370,6 @@ namespace CodeImp.DoomBuilder.BuilderModes
 			General.Interface.RedrawDisplay();
 		}
 
-			#endregion
+		#endregion
 	}
 }

--- a/Source/Plugins/BuilderModes/Resources/Actions.cfg
+++ b/Source/Plugins/BuilderModes/Resources/Actions.cfg
@@ -1317,7 +1317,7 @@ rotateclockwise
 {
 	title = "Rotate Clockwise";
 	category = "edit";
-	description = "Rotates selected or highlighted things clockwise. Also rotates floor/ceiling textures in UDMF map format.";
+	description = "Rotates selected or highlighted things clockwise. Also rotates floor/ceiling textures in UDMF map format, and rotates the selection in Edit Selection mode.";
 	allowkeys = true;
 	allowmouse = false;
 	allowscroll = true;
@@ -1330,7 +1330,7 @@ rotatecounterclockwise
 {
 	title = "Rotate Counterclockwise";
 	category = "edit";
-	description = "Rotates selected or highlighted things counterclockwise. Also rotates floor/ceiling textures in UDMF map format.";
+	description = "Rotates selected or highlighted things counterclockwise. Also rotates floor/ceiling textures in UDMF map format, and rotates the selection in Edit Selection mode.";
 	allowkeys = true;
 	allowmouse = false;
 	allowscroll = true;


### PR DESCRIPTION
Useful when you want to make a quick adjustment to your selection's rotation.

Apologies for the additional commit; VS did some weird stuff with indentation. You might want to squash the commit history when merging this, if that's not already standard procedure.