### PR TITLE
Add explicit PKE resource support (fixes #575)

### DIFF
--- a/Source/Core/Controls/ResourceListEditor.cs
+++ b/Source/Core/Controls/ResourceListEditor.cs
@@ -723,6 +723,7 @@ namespace CodeImp.DoomBuilder.Controls
 								break;
 							case ".pk7":
 							case ".pk3":
+							case ".pke":
                             case ".ipk3":
                             case ".ipk7":
 								if(AddItem(new DataLocation(DataLocation.RESOURCE_PK3, path, false, false, false, null))) addedfiles++;

--- a/Source/Core/Windows/ResourceOptionsForm.Designer.cs
+++ b/Source/Core/Windows/ResourceOptionsForm.Designer.cs
@@ -109,7 +109,7 @@ namespace CodeImp.DoomBuilder.Windows
 			this.tabs.Name = "tabs";
 			this.tabs.Padding = new System.Drawing.Point(16, 3);
 			this.tabs.SelectedIndex = 0;
-			this.tabs.Size = new System.Drawing.Size(369, 237);
+			this.tabs.Size = new System.Drawing.Size(379, 237);
 			this.tabs.TabIndex = 0;
 			// 
 			// wadfiletab
@@ -123,7 +123,7 @@ namespace CodeImp.DoomBuilder.Windows
 			this.wadfiletab.Location = new System.Drawing.Point(4, 22);
 			this.wadfiletab.Name = "wadfiletab";
 			this.wadfiletab.Padding = new System.Windows.Forms.Padding(3);
-			this.wadfiletab.Size = new System.Drawing.Size(361, 211);
+			this.wadfiletab.Size = new System.Drawing.Size(371, 211);
 			this.wadfiletab.TabIndex = 0;
 			this.wadfiletab.Text = "From WAD File";
 			this.wadfiletab.UseVisualStyleBackColor = true;
@@ -132,7 +132,7 @@ namespace CodeImp.DoomBuilder.Windows
 			// 
 			this.label6.Location = new System.Drawing.Point(14, 102);
 			this.label6.Name = "label6";
-			this.label6.Size = new System.Drawing.Size(329, 58);
+			this.label6.Size = new System.Drawing.Size(339, 58);
 			this.label6.TabIndex = 0;
 			this.label6.Text = resources.GetString("label6.Text");
 			// 
@@ -149,7 +149,7 @@ namespace CodeImp.DoomBuilder.Windows
 			// browsewad
 			// 
 			this.browsewad.Image = global::CodeImp.DoomBuilder.Properties.Resources.Folder;
-			this.browsewad.Location = new System.Drawing.Point(315, 35);
+			this.browsewad.Location = new System.Drawing.Point(325, 35);
 			this.browsewad.Name = "browsewad";
 			this.browsewad.Padding = new System.Windows.Forms.Padding(0, 0, 1, 3);
 			this.browsewad.Size = new System.Drawing.Size(28, 24);
@@ -163,7 +163,7 @@ namespace CodeImp.DoomBuilder.Windows
 			this.wadlocation.Location = new System.Drawing.Point(17, 37);
 			this.wadlocation.Name = "wadlocation";
 			this.wadlocation.ReadOnly = true;
-			this.wadlocation.Size = new System.Drawing.Size(292, 20);
+			this.wadlocation.Size = new System.Drawing.Size(302, 20);
 			this.wadlocation.TabIndex = 1;
 			this.wadlocation.TabStop = false;
 			this.wadlocation.Enter += new System.EventHandler(this.wadlocation_Enter);
@@ -181,7 +181,7 @@ namespace CodeImp.DoomBuilder.Windows
 			this.directorytab.Location = new System.Drawing.Point(4, 22);
 			this.directorytab.Name = "directorytab";
 			this.directorytab.Padding = new System.Windows.Forms.Padding(3);
-			this.directorytab.Size = new System.Drawing.Size(361, 211);
+			this.directorytab.Size = new System.Drawing.Size(371, 211);
 			this.directorytab.TabIndex = 1;
 			this.directorytab.Text = "From Directory";
 			this.directorytab.UseVisualStyleBackColor = true;
@@ -192,7 +192,7 @@ namespace CodeImp.DoomBuilder.Windows
 			this.pke_directorylink.LinkColor = System.Drawing.SystemColors.HotTrack;
 			this.pke_directorylink.Location = new System.Drawing.Point(15, 173);
 			this.pke_directorylink.Name = "pke_directorylink";
-			this.pke_directorylink.Size = new System.Drawing.Size(329, 46);
+			this.pke_directorylink.Size = new System.Drawing.Size(339, 46);
 			this.pke_directorylink.TabIndex = 7;
 			this.pke_directorylink.TabStop = true;
 			this.pke_directorylink.Text = "Alternatively, you may use the Eternity PKE directory structure.";
@@ -205,7 +205,7 @@ namespace CodeImp.DoomBuilder.Windows
 			this.pk3_directorylink.LinkColor = System.Drawing.SystemColors.HotTrack;
 			this.pk3_directorylink.Location = new System.Drawing.Point(14, 127);
 			this.pk3_directorylink.Name = "pk3_directorylink";
-			this.pk3_directorylink.Size = new System.Drawing.Size(329, 58);
+			this.pk3_directorylink.Size = new System.Drawing.Size(339, 58);
 			this.pk3_directorylink.TabIndex = 1;
 			this.pk3_directorylink.TabStop = true;
 			this.pk3_directorylink.Text = "The directory may use the ZDoom PK3 directory structure, or you can choose to use" +
@@ -265,7 +265,7 @@ namespace CodeImp.DoomBuilder.Windows
 			this.pk3filetab.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
 			this.pk3filetab.Location = new System.Drawing.Point(4, 22);
 			this.pk3filetab.Name = "pk3filetab";
-			this.pk3filetab.Size = new System.Drawing.Size(361, 211);
+			this.pk3filetab.Size = new System.Drawing.Size(371, 211);
 			this.pk3filetab.TabIndex = 2;
 			this.pk3filetab.Text = "From PK3/PKE/PK7";
 			this.pk3filetab.UseVisualStyleBackColor = true;
@@ -276,7 +276,7 @@ namespace CodeImp.DoomBuilder.Windows
 			this.pkelink.LinkColor = System.Drawing.SystemColors.HotTrack;
 			this.pkelink.Location = new System.Drawing.Point(15, 111);
 			this.pkelink.Name = "pkelink";
-			this.pkelink.Size = new System.Drawing.Size(328, 47);
+			this.pkelink.Size = new System.Drawing.Size(338, 47);
 			this.pkelink.TabIndex = 8;
 			this.pkelink.TabStop = true;
 			this.pkelink.Text = "PKE archive files are expected to use the Eternity archive directory structure.";
@@ -289,7 +289,7 @@ namespace CodeImp.DoomBuilder.Windows
 			this.pk3link.LinkColor = System.Drawing.SystemColors.HotTrack;
 			this.pk3link.Location = new System.Drawing.Point(15, 72);
 			this.pk3link.Name = "pk3link";
-			this.pk3link.Size = new System.Drawing.Size(328, 47);
+			this.pk3link.Size = new System.Drawing.Size(338, 47);
 			this.pk3link.TabIndex = 7;
 			this.pk3link.TabStop = true;
 			this.pk3link.Text = "PK3 and PK7 archive files are expected to use the ZDoom archive directory structu" +
@@ -300,7 +300,7 @@ namespace CodeImp.DoomBuilder.Windows
 			// browsepk3
 			// 
 			this.browsepk3.Image = global::CodeImp.DoomBuilder.Properties.Resources.Folder;
-			this.browsepk3.Location = new System.Drawing.Point(315, 35);
+			this.browsepk3.Location = new System.Drawing.Point(325, 35);
 			this.browsepk3.Name = "browsepk3";
 			this.browsepk3.Padding = new System.Windows.Forms.Padding(0, 0, 1, 3);
 			this.browsepk3.Size = new System.Drawing.Size(28, 24);
@@ -313,7 +313,7 @@ namespace CodeImp.DoomBuilder.Windows
 			this.pk3location.Location = new System.Drawing.Point(17, 37);
 			this.pk3location.Name = "pk3location";
 			this.pk3location.ReadOnly = true;
-			this.pk3location.Size = new System.Drawing.Size(292, 20);
+			this.pk3location.Size = new System.Drawing.Size(302, 20);
 			this.pk3location.TabIndex = 0;
 			this.pk3location.TabStop = false;
 			this.pk3location.Enter += new System.EventHandler(this.pk3location_Enter);
@@ -322,7 +322,7 @@ namespace CodeImp.DoomBuilder.Windows
 			// 
 			this.cancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
 			this.cancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-			this.cancel.Location = new System.Drawing.Point(262, 330);
+			this.cancel.Location = new System.Drawing.Point(272, 330);
 			this.cancel.Name = "cancel";
 			this.cancel.Size = new System.Drawing.Size(112, 25);
 			this.cancel.TabIndex = 2;
@@ -333,7 +333,7 @@ namespace CodeImp.DoomBuilder.Windows
 			// apply
 			// 
 			this.apply.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.apply.Location = new System.Drawing.Point(144, 330);
+			this.apply.Location = new System.Drawing.Point(154, 330);
 			this.apply.Name = "apply";
 			this.apply.Size = new System.Drawing.Size(112, 25);
 			this.apply.TabIndex = 1;
@@ -375,7 +375,7 @@ namespace CodeImp.DoomBuilder.Windows
 			this.checkingloader.ForeColor = System.Drawing.SystemColors.InfoText;
 			this.checkingloader.Location = new System.Drawing.Point(12, 289);
 			this.checkingloader.Name = "checkingloader";
-			this.checkingloader.Size = new System.Drawing.Size(362, 32);
+			this.checkingloader.Size = new System.Drawing.Size(372, 32);
 			this.checkingloader.TabIndex = 4;
 			this.checkingloader.Visible = false;
 			// 
@@ -404,7 +404,7 @@ namespace CodeImp.DoomBuilder.Windows
 			this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
 			this.CancelButton = this.cancel;
-			this.ClientSize = new System.Drawing.Size(386, 363);
+			this.ClientSize = new System.Drawing.Size(396, 363);
 			this.Controls.Add(this.checkingloader);
 			this.Controls.Add(this.notfortesting);
 			this.Controls.Add(this.cancel);

--- a/Source/Core/Windows/ResourceOptionsForm.Designer.cs
+++ b/Source/Core/Windows/ResourceOptionsForm.Designer.cs
@@ -39,12 +39,14 @@ namespace CodeImp.DoomBuilder.Windows
 			this.browsewad = new System.Windows.Forms.Button();
 			this.wadlocation = new System.Windows.Forms.TextBox();
 			this.directorytab = new System.Windows.Forms.TabPage();
-			this.directorylink = new System.Windows.Forms.LinkLabel();
+			this.pke_directorylink = new System.Windows.Forms.LinkLabel();
+			this.pk3_directorylink = new System.Windows.Forms.LinkLabel();
 			this.dir_flats = new System.Windows.Forms.CheckBox();
 			this.dir_textures = new System.Windows.Forms.CheckBox();
 			this.browsedir = new System.Windows.Forms.Button();
 			this.dirlocation = new System.Windows.Forms.TextBox();
 			this.pk3filetab = new System.Windows.Forms.TabPage();
+			this.pkelink = new System.Windows.Forms.LinkLabel();
 			this.pk3link = new System.Windows.Forms.LinkLabel();
 			this.browsepk3 = new System.Windows.Forms.Button();
 			this.pk3location = new System.Windows.Forms.TextBox();
@@ -90,7 +92,7 @@ namespace CodeImp.DoomBuilder.Windows
 			label3.AutoSize = true;
 			label3.Location = new System.Drawing.Point(15, 20);
 			label3.Name = "label3";
-			label3.Size = new System.Drawing.Size(133, 13);
+			label3.Size = new System.Drawing.Size(163, 13);
 			label3.TabIndex = 3;
 			label3.Text = "PK3, PKE, or PK7 File Resource:";
 			// 
@@ -107,7 +109,7 @@ namespace CodeImp.DoomBuilder.Windows
 			this.tabs.Name = "tabs";
 			this.tabs.Padding = new System.Drawing.Point(16, 3);
 			this.tabs.SelectedIndex = 0;
-			this.tabs.Size = new System.Drawing.Size(369, 211);
+			this.tabs.Size = new System.Drawing.Size(369, 237);
 			this.tabs.TabIndex = 0;
 			// 
 			// wadfiletab
@@ -121,7 +123,7 @@ namespace CodeImp.DoomBuilder.Windows
 			this.wadfiletab.Location = new System.Drawing.Point(4, 22);
 			this.wadfiletab.Name = "wadfiletab";
 			this.wadfiletab.Padding = new System.Windows.Forms.Padding(3);
-			this.wadfiletab.Size = new System.Drawing.Size(361, 185);
+			this.wadfiletab.Size = new System.Drawing.Size(361, 211);
 			this.wadfiletab.TabIndex = 0;
 			this.wadfiletab.Text = "From WAD File";
 			this.wadfiletab.UseVisualStyleBackColor = true;
@@ -168,7 +170,8 @@ namespace CodeImp.DoomBuilder.Windows
 			// 
 			// directorytab
 			// 
-			this.directorytab.Controls.Add(this.directorylink);
+			this.directorytab.Controls.Add(this.pke_directorylink);
+			this.directorytab.Controls.Add(this.pk3_directorylink);
 			this.directorytab.Controls.Add(this.dir_flats);
 			this.directorytab.Controls.Add(this.dir_textures);
 			this.directorytab.Controls.Add(this.browsedir);
@@ -178,24 +181,37 @@ namespace CodeImp.DoomBuilder.Windows
 			this.directorytab.Location = new System.Drawing.Point(4, 22);
 			this.directorytab.Name = "directorytab";
 			this.directorytab.Padding = new System.Windows.Forms.Padding(3);
-			this.directorytab.Size = new System.Drawing.Size(361, 185);
+			this.directorytab.Size = new System.Drawing.Size(361, 211);
 			this.directorytab.TabIndex = 1;
 			this.directorytab.Text = "From Directory";
 			this.directorytab.UseVisualStyleBackColor = true;
 			// 
-			// directorylink
+			// pke_directorylink
 			// 
-			this.directorylink.LinkArea = new System.Windows.Forms.LinkArea(26, 29);
-			this.directorylink.LinkColor = System.Drawing.SystemColors.HotTrack;
-			this.directorylink.Location = new System.Drawing.Point(14, 127);
-			this.directorylink.Name = "directorylink";
-			this.directorylink.Size = new System.Drawing.Size(329, 54);
-			this.directorylink.TabIndex = 1;
-			this.directorylink.TabStop = true;
-			this.directorylink.Text = "The directory may use the ZDoom PK3 directory structure, or you can choose to use" +
+			this.pke_directorylink.LinkArea = new System.Windows.Forms.LinkArea(31, 32);
+			this.pke_directorylink.LinkColor = System.Drawing.SystemColors.HotTrack;
+			this.pke_directorylink.Location = new System.Drawing.Point(15, 173);
+			this.pke_directorylink.Name = "pke_directorylink";
+			this.pke_directorylink.Size = new System.Drawing.Size(329, 46);
+			this.pke_directorylink.TabIndex = 7;
+			this.pke_directorylink.TabStop = true;
+			this.pke_directorylink.Text = "Alternatively, you may use the Eternity PKE directory structure.";
+			this.pke_directorylink.UseCompatibleTextRendering = true;
+			this.pke_directorylink.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.pke_link_Click);
+			// 
+			// pk3_directorylink
+			// 
+			this.pk3_directorylink.LinkArea = new System.Windows.Forms.LinkArea(26, 29);
+			this.pk3_directorylink.LinkColor = System.Drawing.SystemColors.HotTrack;
+			this.pk3_directorylink.Location = new System.Drawing.Point(14, 127);
+			this.pk3_directorylink.Name = "pk3_directorylink";
+			this.pk3_directorylink.Size = new System.Drawing.Size(329, 58);
+			this.pk3_directorylink.TabIndex = 1;
+			this.pk3_directorylink.TabStop = true;
+			this.pk3_directorylink.Text = "The directory may use the ZDoom PK3 directory structure, or you can choose to use" +
     " the options above to load texture or flat images from the directory root.";
-			this.directorylink.UseCompatibleTextRendering = true;
-			this.directorylink.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.link_Click);
+			this.pk3_directorylink.UseCompatibleTextRendering = true;
+			this.pk3_directorylink.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.pk3_link_Click);
 			// 
 			// dir_flats
 			// 
@@ -241,6 +257,7 @@ namespace CodeImp.DoomBuilder.Windows
 			// 
 			// pk3filetab
 			// 
+			this.pk3filetab.Controls.Add(this.pkelink);
 			this.pk3filetab.Controls.Add(this.pk3link);
 			this.pk3filetab.Controls.Add(this.browsepk3);
 			this.pk3filetab.Controls.Add(this.pk3location);
@@ -248,23 +265,37 @@ namespace CodeImp.DoomBuilder.Windows
 			this.pk3filetab.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
 			this.pk3filetab.Location = new System.Drawing.Point(4, 22);
 			this.pk3filetab.Name = "pk3filetab";
-			this.pk3filetab.Size = new System.Drawing.Size(361, 185);
+			this.pk3filetab.Size = new System.Drawing.Size(361, 211);
 			this.pk3filetab.TabIndex = 2;
 			this.pk3filetab.Text = "From PK3/PKE/PK7";
 			this.pk3filetab.UseVisualStyleBackColor = true;
 			// 
+			// pkelink
+			// 
+			this.pkelink.LinkArea = new System.Windows.Forms.LinkArea(42, 36);
+			this.pkelink.LinkColor = System.Drawing.SystemColors.HotTrack;
+			this.pkelink.Location = new System.Drawing.Point(15, 111);
+			this.pkelink.Name = "pkelink";
+			this.pkelink.Size = new System.Drawing.Size(328, 47);
+			this.pkelink.TabIndex = 8;
+			this.pkelink.TabStop = true;
+			this.pkelink.Text = "PKE archive files are expected to use the Eternity archive directory structure.";
+			this.pkelink.UseCompatibleTextRendering = true;
+			this.pkelink.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.pke_link_Click);
+			// 
 			// pk3link
 			// 
-			this.pk3link.LinkArea = new System.Windows.Forms.LinkArea(40, 33);
+			this.pk3link.LinkArea = new System.Windows.Forms.LinkArea(50, 33);
 			this.pk3link.LinkColor = System.Drawing.SystemColors.HotTrack;
 			this.pk3link.Location = new System.Drawing.Point(15, 72);
 			this.pk3link.Name = "pk3link";
 			this.pk3link.Size = new System.Drawing.Size(328, 47);
 			this.pk3link.TabIndex = 7;
 			this.pk3link.TabStop = true;
-			this.pk3link.Text = "The archive file is expected to use the ZDoom archive directory structure.";
+			this.pk3link.Text = "PK3 and PK7 archive files are expected to use the ZDoom archive directory structu" +
+    "re.";
 			this.pk3link.UseCompatibleTextRendering = true;
-			this.pk3link.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.link_Click);
+			this.pk3link.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.pk3_link_Click);
 			// 
 			// browsepk3
 			// 
@@ -291,7 +322,7 @@ namespace CodeImp.DoomBuilder.Windows
 			// 
 			this.cancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
 			this.cancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-			this.cancel.Location = new System.Drawing.Point(262, 304);
+			this.cancel.Location = new System.Drawing.Point(262, 330);
 			this.cancel.Name = "cancel";
 			this.cancel.Size = new System.Drawing.Size(112, 25);
 			this.cancel.TabIndex = 2;
@@ -302,7 +333,7 @@ namespace CodeImp.DoomBuilder.Windows
 			// apply
 			// 
 			this.apply.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.apply.Location = new System.Drawing.Point(144, 304);
+			this.apply.Location = new System.Drawing.Point(144, 330);
 			this.apply.Name = "apply";
 			this.apply.Size = new System.Drawing.Size(112, 25);
 			this.apply.TabIndex = 1;
@@ -317,14 +348,15 @@ namespace CodeImp.DoomBuilder.Windows
 			// 
 			// pk3filedialog
 			// 
-			this.pk3filedialog.Filter = "Doom PK3/PKE/PK7 Files (*.pk3;*.pke;*.pk7;*.ipk3;*.ipk7)|*.pk3;*.pke;*.pk7;*.ipk3;*.ipk7";
+			this.pk3filedialog.Filter = "Doom PK3/PKE/PK7 Files (*.pk3;*.pke;*.pk7;*.ipk3;*.ipk7)|*.pk3;*.pke;*.pk7;*.ipk3" +
+    ";*.ipk7";
 			this.pk3filedialog.Title = "Browse PK3, PKE, or PK7 File";
 			// 
 			// notfortesting
 			// 
 			this.notfortesting.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
 			this.notfortesting.AutoSize = true;
-			this.notfortesting.Location = new System.Drawing.Point(12, 233);
+			this.notfortesting.Location = new System.Drawing.Point(12, 260);
 			this.notfortesting.Name = "notfortesting";
 			this.notfortesting.Size = new System.Drawing.Size(239, 17);
 			this.notfortesting.TabIndex = 3;
@@ -341,7 +373,7 @@ namespace CodeImp.DoomBuilder.Windows
 			this.checkingloader.Controls.Add(this.label4);
 			this.checkingloader.Cursor = System.Windows.Forms.Cursors.AppStarting;
 			this.checkingloader.ForeColor = System.Drawing.SystemColors.InfoText;
-			this.checkingloader.Location = new System.Drawing.Point(12, 263);
+			this.checkingloader.Location = new System.Drawing.Point(12, 289);
 			this.checkingloader.Name = "checkingloader";
 			this.checkingloader.Size = new System.Drawing.Size(362, 32);
 			this.checkingloader.TabIndex = 4;
@@ -372,7 +404,7 @@ namespace CodeImp.DoomBuilder.Windows
 			this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
 			this.CancelButton = this.cancel;
-			this.ClientSize = new System.Drawing.Size(386, 337);
+			this.ClientSize = new System.Drawing.Size(386, 363);
 			this.Controls.Add(this.checkingloader);
 			this.Controls.Add(this.notfortesting);
 			this.Controls.Add(this.cancel);
@@ -422,12 +454,14 @@ namespace CodeImp.DoomBuilder.Windows
 		private System.Windows.Forms.TextBox pk3location;
 		private System.Windows.Forms.OpenFileDialog pk3filedialog;
 		private System.Windows.Forms.LinkLabel pk3link;
-		private System.Windows.Forms.LinkLabel directorylink;
+		private System.Windows.Forms.LinkLabel pk3_directorylink;
 		private System.Windows.Forms.CheckBox strictpatches;
 		private System.Windows.Forms.Label label6;
 		private System.Windows.Forms.CheckBox notfortesting;
         private System.Windows.Forms.Panel checkingloader;
         private System.Windows.Forms.Label label4;
         private System.Windows.Forms.PictureBox pictureBox1;
+        private System.Windows.Forms.LinkLabel pkelink;
+        private System.Windows.Forms.LinkLabel pke_directorylink;
     }
 }

--- a/Source/Core/Windows/ResourceOptionsForm.Designer.cs
+++ b/Source/Core/Windows/ResourceOptionsForm.Designer.cs
@@ -185,17 +185,16 @@ namespace CodeImp.DoomBuilder.Windows
 			// 
 			// directorylink
 			// 
+			this.directorylink.LinkArea = new System.Windows.Forms.LinkArea(26, 29);
 			this.directorylink.LinkColor = System.Drawing.SystemColors.HotTrack;
 			this.directorylink.Location = new System.Drawing.Point(14, 127);
 			this.directorylink.Name = "directorylink";
 			this.directorylink.Size = new System.Drawing.Size(329, 54);
 			this.directorylink.TabIndex = 1;
 			this.directorylink.TabStop = true;
-			this.directorylink.Text = "The directory may use the ZDoom PK3 directory structure, Eternity PKE directory structure," +
-	" or you can choose to use the options above to load texture or flat images from the directory root.";
+			this.directorylink.Text = "The directory may use the ZDoom PK3 directory structure, or you can choose to use" +
+    " the options above to load texture or flat images from the directory root.";
 			this.directorylink.UseCompatibleTextRendering = true;
-			this.directorylink.Links.Add(26, 29, LinkType.ZDOOM);
-			this.directorylink.Links.Add(57, 32, LinkType.ETERNITY);
 			this.directorylink.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.link_Click);
 			// 
 			// dir_flats
@@ -256,18 +255,16 @@ namespace CodeImp.DoomBuilder.Windows
 			// 
 			// pk3link
 			// 
+			this.pk3link.LinkArea = new System.Windows.Forms.LinkArea(40, 33);
 			this.pk3link.LinkColor = System.Drawing.SystemColors.HotTrack;
 			this.pk3link.Location = new System.Drawing.Point(15, 72);
 			this.pk3link.Name = "pk3link";
 			this.pk3link.Size = new System.Drawing.Size(328, 47);
 			this.pk3link.TabIndex = 7;
 			this.pk3link.TabStop = true;
-			this.pk3link.Text = "PK3 and PK7 archive files are expected to use the ZDoom archive directory structure." +
-	" PKE archive files are expected to use the Eternity archive directory structure.";
+			this.pk3link.Text = "The archive file is expected to use the ZDoom archive directory structure.";
 			this.pk3link.UseCompatibleTextRendering = true;
-			this.pk3link.Links.Add(50, 33, LinkType.ZDOOM);
-			this.pk3link.Links.Add(123, 40, LinkType.ETERNITY);
-            this.pk3link.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.link_Click);
+			this.pk3link.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.link_Click);
 			// 
 			// browsepk3
 			// 

--- a/Source/Core/Windows/ResourceOptionsForm.Designer.cs
+++ b/Source/Core/Windows/ResourceOptionsForm.Designer.cs
@@ -92,7 +92,7 @@ namespace CodeImp.DoomBuilder.Windows
 			label3.Name = "label3";
 			label3.Size = new System.Drawing.Size(133, 13);
 			label3.TabIndex = 3;
-			label3.Text = "PK3 or PK7 File Resource:";
+			label3.Text = "PK3, PKE, or PK7 File Resource:";
 			// 
 			// tabs
 			// 
@@ -250,7 +250,7 @@ namespace CodeImp.DoomBuilder.Windows
 			this.pk3filetab.Name = "pk3filetab";
 			this.pk3filetab.Size = new System.Drawing.Size(361, 185);
 			this.pk3filetab.TabIndex = 2;
-			this.pk3filetab.Text = "From PK3/PK7";
+			this.pk3filetab.Text = "From PK3/PKE/PK7";
 			this.pk3filetab.UseVisualStyleBackColor = true;
 			// 
 			// pk3link
@@ -317,8 +317,8 @@ namespace CodeImp.DoomBuilder.Windows
 			// 
 			// pk3filedialog
 			// 
-			this.pk3filedialog.Filter = "Doom PK3/PK7 Files (*.pk3;*.pk7;*.ipk3;*.ipk7)|*.pk3;*.pk7;*.ipk3;*.ipk7";
-			this.pk3filedialog.Title = "Browse PK3 or PK7 File";
+			this.pk3filedialog.Filter = "Doom PK3/PKE/PK7 Files (*.pk3;*.pke;*.pk7;*.ipk3;*.ipk7)|*.pk3;*.pke;*.pk7;*.ipk3;*.ipk7";
+			this.pk3filedialog.Title = "Browse PK3, PKE, or PK7 File";
 			// 
 			// notfortesting
 			// 

--- a/Source/Core/Windows/ResourceOptionsForm.Designer.cs
+++ b/Source/Core/Windows/ResourceOptionsForm.Designer.cs
@@ -185,16 +185,17 @@ namespace CodeImp.DoomBuilder.Windows
 			// 
 			// directorylink
 			// 
-			this.directorylink.LinkArea = new System.Windows.Forms.LinkArea(26, 29);
 			this.directorylink.LinkColor = System.Drawing.SystemColors.HotTrack;
 			this.directorylink.Location = new System.Drawing.Point(14, 127);
 			this.directorylink.Name = "directorylink";
 			this.directorylink.Size = new System.Drawing.Size(329, 54);
 			this.directorylink.TabIndex = 1;
 			this.directorylink.TabStop = true;
-			this.directorylink.Text = "The directory may use the ZDoom PK3 directory structure, or you can choose to use" +
-    " the options above to load texture or flat images from the directory root.";
+			this.directorylink.Text = "The directory may use the ZDoom PK3 directory structure, Eternity PKE directory structure," +
+	" or you can choose to use the options above to load texture or flat images from the directory root.";
 			this.directorylink.UseCompatibleTextRendering = true;
+			this.directorylink.Links.Add(26, 29, LinkType.ZDOOM);
+			this.directorylink.Links.Add(57, 32, LinkType.ETERNITY);
 			this.directorylink.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.link_Click);
 			// 
 			// dir_flats
@@ -255,16 +256,18 @@ namespace CodeImp.DoomBuilder.Windows
 			// 
 			// pk3link
 			// 
-			this.pk3link.LinkArea = new System.Windows.Forms.LinkArea(40, 33);
 			this.pk3link.LinkColor = System.Drawing.SystemColors.HotTrack;
 			this.pk3link.Location = new System.Drawing.Point(15, 72);
 			this.pk3link.Name = "pk3link";
 			this.pk3link.Size = new System.Drawing.Size(328, 47);
 			this.pk3link.TabIndex = 7;
 			this.pk3link.TabStop = true;
-			this.pk3link.Text = "The archive file is expected to use the ZDoom archive directory structure.";
+			this.pk3link.Text = "PK3 and PK7 archive files are expected to use the ZDoom archive directory structure." +
+	" PKE archive files are expected to use the Eternity archive directory structure.";
 			this.pk3link.UseCompatibleTextRendering = true;
-			this.pk3link.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.link_Click);
+			this.pk3link.Links.Add(50, 33, LinkType.ZDOOM);
+			this.pk3link.Links.Add(123, 40, LinkType.ETERNITY);
+            this.pk3link.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.link_Click);
 			// 
 			// browsepk3
 			// 

--- a/Source/Core/Windows/ResourceOptionsForm.cs
+++ b/Source/Core/Windows/ResourceOptionsForm.cs
@@ -33,8 +33,15 @@ namespace CodeImp.DoomBuilder.Windows
 {
 	internal partial class ResourceOptionsForm : DelayedForm
 	{
-		// Variables
-		private DataLocation res;
+		// Types
+        private enum LinkType
+		{
+			ZDOOM,
+			ETERNITY
+		}
+
+        // Variables
+        private DataLocation res;
         private string startPath;
         private Controls.FolderSelectDialog dirdialog;
 		private List<string> requiredarchives;
@@ -504,7 +511,14 @@ namespace CodeImp.DoomBuilder.Windows
 		// Link clicked
 		private void link_Click(object sender, LinkLabelLinkClickedEventArgs e)
 		{
-			General.OpenWebsite("http://www.zdoom.org/wiki/Using_ZIPs_as_WAD_replacement");
+			if(e.Link.LinkData is LinkType.ETERNITY)
+			{
+				General.OpenWebsite("https://eternity.youfailit.net/wiki/ZIP");
+			}
+			else
+			{
+				General.OpenWebsite("http://www.zdoom.org/wiki/Using_ZIPs_as_WAD_replacement");
+			}
 		}
 
 		// Help

--- a/Source/Core/Windows/ResourceOptionsForm.cs
+++ b/Source/Core/Windows/ResourceOptionsForm.cs
@@ -502,9 +502,14 @@ namespace CodeImp.DoomBuilder.Windows
 		}
 
 		// Link clicked
-		private void link_Click(object sender, LinkLabelLinkClickedEventArgs e)
+		private void pk3_link_Click(object sender, LinkLabelLinkClickedEventArgs e)
 		{
 			General.OpenWebsite("http://www.zdoom.org/wiki/Using_ZIPs_as_WAD_replacement");
+		}
+
+		private void pke_link_Click(object sender, LinkLabelLinkClickedEventArgs e)
+		{
+			General.OpenWebsite("https://eternity.youfailit.net/wiki/ZIP");
 		}
 
 		// Help

--- a/Source/Core/Windows/ResourceOptionsForm.cs
+++ b/Source/Core/Windows/ResourceOptionsForm.cs
@@ -86,8 +86,9 @@ namespace CodeImp.DoomBuilder.Windows
 #if NO_WIN32
 			// No easy way to have case-insesitivity for non-Windows platforms
 			wadfiledialog.Filter = "Doom WAD Files (*.wad)|*.wad;*.Wad;*.wAd;*.WAd;*.waD;*.WaD;*.wAD;*.WAD";
-			pk3filedialog.Filter = "Doom PK3/PK7 Files (*.pk3;*.pk7;*.ipk3;*.ipk7)|" +
+			pk3filedialog.Filter = "Doom PK3/PKE/PK7 Files (*.pk3;*.pke;*.pk7;*.ipk3;*.ipk7)|" +
 				"*.pk3;*.Pk3;*.pK3;*.PK3;" +
+				"*.pke;*.Pke;*.pKe;*.PKe;*.pkE;*.PkE;*.pKE;*.PKE;" +
 				"*.pk7;*.Pk7;*.pK7;*.PK7;" +
 				"*.ipk3;*.iPk3;*.ipK3;*.iPK3;*.Ipk3;*.IPk3;*.IpK3;*.IPK3;" +
 				"*.ipk7;*.iPk7;*.ipK7;*.iPK7;*.Ipk7;*.IPk7;*.IpK7;*.IPK7";
@@ -329,7 +330,7 @@ namespace CodeImp.DoomBuilder.Windows
 			dir_textures.Checked = false;
 			dir_flats.Checked = false;
 			notfortesting.Checked = false;
-			// if any of the detected required archives implies "not for testing" — disable it by default
+			// if any of the detected required archives implies "not for testing" ï¿½ disable it by default
 			foreach (var arc in GameConfiguration.RequiredArchives)
             {
 				if (requiredarchives.Contains(arc.ID) && arc.ExcludeFromTesting)
@@ -423,7 +424,7 @@ namespace CodeImp.DoomBuilder.Windows
 						break;
 
 					case DataLocation.RESOURCE_PK3:
-						MessageBox.Show(this, "Please select a valid PK3 or PK7 File resource.", Application.ProductName, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+						MessageBox.Show(this, "Please select a valid PK3, PKE, or PK7 File resource.", Application.ProductName, MessageBoxButtons.OK, MessageBoxIcon.Warning);
 						break;
 
 					case DataLocation.RESOURCE_DIRECTORY:

--- a/Source/Core/Windows/ResourceOptionsForm.cs
+++ b/Source/Core/Windows/ResourceOptionsForm.cs
@@ -33,15 +33,8 @@ namespace CodeImp.DoomBuilder.Windows
 {
 	internal partial class ResourceOptionsForm : DelayedForm
 	{
-		// Types
-        private enum LinkType
-		{
-			ZDOOM,
-			ETERNITY
-		}
-
-        // Variables
-        private DataLocation res;
+		// Variables
+		private DataLocation res;
         private string startPath;
         private Controls.FolderSelectDialog dirdialog;
 		private List<string> requiredarchives;
@@ -511,14 +504,7 @@ namespace CodeImp.DoomBuilder.Windows
 		// Link clicked
 		private void link_Click(object sender, LinkLabelLinkClickedEventArgs e)
 		{
-			if(e.Link.LinkData is LinkType.ETERNITY)
-			{
-				General.OpenWebsite("https://eternity.youfailit.net/wiki/ZIP");
-			}
-			else
-			{
-				General.OpenWebsite("http://www.zdoom.org/wiki/Using_ZIPs_as_WAD_replacement");
-			}
+			General.OpenWebsite("http://www.zdoom.org/wiki/Using_ZIPs_as_WAD_replacement");
 		}
 
 		// Help


### PR DESCRIPTION
I've kept this as simple as humanly possible. No awkward extensions of text to link to the EE wiki's ZIP page (it's basically the same as ZDoom but less fully-featured), no trying to genericise terms, just adding "PKE" in text where necessary. No functionality had to be changed at all, since it's just good ole ZIPs.