### PR TITLE
More ZDRay fixes

### DIFF
--- a/Build/Configurations/Includes/GZDoom_things.cfg
+++ b/Build/Configurations/Includes/GZDoom_things.cfg
@@ -79,7 +79,6 @@ gzdoom_lights
 			{
 				lm_suncolor;
 				lm_sampledistance;
-				lm_gridsize;
 			}
 		}
 	}

--- a/Build/Configurations/Includes/ZDoom_misc.cfg
+++ b/Build/Configurations/Includes/ZDoom_misc.cfg
@@ -747,14 +747,7 @@ universalfields
 		lm_sampledistance
 		{
 			type = 0;
-			default = 8;
-			thingtypespecific = true;
-		}
-
-		lm_gridsize
-		{
-			type = 1;
-			default = 32.0;
+			default = 16;
 			thingtypespecific = true;
 		}
 	}


### PR DESCRIPTION
- Removed lightmap grid size (ZDRay doesn't use light probes anymore)
- Fix the default lightmap sample distance to match ZDRay's