### PR TITLE
Sound Propagation Mode: added sound leak finder

### DIFF
--- a/Source/Core/Data/ResourceImage.cs
+++ b/Source/Core/Data/ResourceImage.cs
@@ -46,8 +46,6 @@ namespace CodeImp.DoomBuilder.Data
 			this.AllowUnload = false;
 			SetName(resourcename);
 
-			var x = assembly.GetManifestResourceNames();
-
 			// Temporarily load resource from memory
 			Stream bitmapdata = assembly.GetManifestResourceStream(resourcename); 
 			Bitmap bmp = (Bitmap)Image.FromStream(bitmapdata);

--- a/Source/Core/Data/ResourceImage.cs
+++ b/Source/Core/Data/ResourceImage.cs
@@ -46,8 +46,10 @@ namespace CodeImp.DoomBuilder.Data
 			this.AllowUnload = false;
 			SetName(resourcename);
 
+			var x = assembly.GetManifestResourceNames();
+
 			// Temporarily load resource from memory
-			Stream bitmapdata = assembly.GetManifestResourceStream(resourcename);
+			Stream bitmapdata = assembly.GetManifestResourceStream(resourcename); 
 			Bitmap bmp = (Bitmap)Image.FromStream(bitmapdata);
 
 			// Get width and height from image

--- a/Source/Core/Rendering/IRenderer2D.cs
+++ b/Source/Core/Rendering/IRenderer2D.cs
@@ -69,6 +69,7 @@ namespace CodeImp.DoomBuilder.Rendering
 		void PlotVerticesSet(ICollection<Vertex> vertices, bool checkMode = true);
 		void RenderThing(Thing t, PixelColor c, float alpha);
 		void RenderThingSet(ICollection<Thing> things, float alpha);
+		void RenderThingSet(ICollection<Thing> things, PixelColor c, float alpha);
 		void RenderRectangle(RectangleF rect, float bordersize, PixelColor c, bool transformrect);
 		void RenderRectangleFilled(RectangleF rect, PixelColor c, bool transformrect);
 		void RenderRectangleFilled(RectangleF rect, PixelColor c, bool transformrect, ImageData texture);

--- a/Source/Core/Rendering/IRenderer2D.cs
+++ b/Source/Core/Rendering/IRenderer2D.cs
@@ -52,7 +52,7 @@ namespace CodeImp.DoomBuilder.Rendering
 		// Rendering management methods
 		bool StartPlotter(bool clear);
 		bool StartThings(bool clear);
-		bool StartOverlay(bool clear);
+		bool StartOverlay(bool clear, int layernum = 0);
 		void Finish();
 		void SetPresentation(Presentation present);
 		void Present();

--- a/Source/Core/Rendering/Renderer2D.cs
+++ b/Source/Core/Rendering/Renderer2D.cs
@@ -1580,7 +1580,14 @@ namespace CodeImp.DoomBuilder.Rendering
 		{
 			RenderThingsBatch(things, alpha, false, new PixelColor());
 		}
-		
+
+		// This adds a thing in the things buffer for rendering
+		public void RenderThingSet(ICollection<Thing> things, PixelColor c, float alpha)
+		{
+			RenderThingsBatch(things, alpha, false, c);
+		}
+
+
 		#endregion
 
 		#region ================== Surface

--- a/Source/Core/Rendering/Renderer2D.cs
+++ b/Source/Core/Rendering/Renderer2D.cs
@@ -27,6 +27,7 @@ using CodeImp.DoomBuilder.Editing;
 using CodeImp.DoomBuilder.GZBuilder.Data; //mxd
 using CodeImp.DoomBuilder.Config; //mxd
 using CodeImp.DoomBuilder.GZBuilder;
+using System.Linq;
 
 #endregion
 
@@ -63,7 +64,7 @@ namespace CodeImp.DoomBuilder.Rendering
 		private Plotter gridplotter;
         private Plotter plotter;
         private Texture thingstex;
-		private Texture overlaytex;
+		private List<Texture> overlaytex;
 		private Texture surfacetex;
 
 		// Rendertarget sizes
@@ -179,11 +180,22 @@ namespace CodeImp.DoomBuilder.Rendering
 		public void SetPresentation(Presentation present)
 		{
 			this.present = new Presentation(present);
+
+			// We might have to create additional overlay textures
+			int numoverlaylayers = present.layers.Count(l => l.layer == RendererLayer.Overlay);
+			if(numoverlaylayers > overlaytex.Count)
+			{
+				Texture t = new Texture(windowsize.Width, windowsize.Height, TextureFormat.Rgba8);
+				graphics.ClearTexture(General.Colors.Background.WithAlpha(0).ToColorValue(), t);
+				overlaytex.Add(t);
+			}
 		}
 		
 		// This draws the image on screen
 		public void Present()
 		{
+			int currentoverlaylayer = 0;
+
 			General.Plugins.OnPresentDisplayBegin();
 
             // Start drawing
@@ -279,10 +291,11 @@ namespace CodeImp.DoomBuilder.Rendering
 					// OVERLAY
 					case RendererLayer.Overlay:
                         graphics.SetShader(aapass);
-                        graphics.SetTexture(overlaytex);
+                        graphics.SetTexture(overlaytex[currentoverlaylayer]);
 						graphics.SetSamplerState(TextureAddress.Wrap);
-						SetDisplay2DSettings(1f / overlaytex.Width, 1f / overlaytex.Height, FSAA_FACTOR, layer.alpha, false, true);
+						SetDisplay2DSettings(1f / overlaytex[currentoverlaylayer].Width, 1f / overlaytex[currentoverlaylayer].Height, FSAA_FACTOR, layer.alpha, false, true);
 						graphics.Draw(PrimitiveType.TriangleStrip, 0, 2);
+						currentoverlaylayer++;
 						break;
 
 					// SURFACE
@@ -290,7 +303,7 @@ namespace CodeImp.DoomBuilder.Rendering
                         graphics.SetShader(aapass);
                         graphics.SetTexture(surfacetex);
 						graphics.SetSamplerState(TextureAddress.Wrap);
-						SetDisplay2DSettings(1f / overlaytex.Width, 1f / overlaytex.Height, FSAA_FACTOR, layer.alpha, false, true);
+						SetDisplay2DSettings(1f / surfacetex.Width, 1f / surfacetex.Height, FSAA_FACTOR, layer.alpha, false, true);
 						graphics.Draw(PrimitiveType.TriangleStrip, 0, 2);
 						break;
 				}
@@ -336,12 +349,12 @@ namespace CodeImp.DoomBuilder.Rendering
 		public void DestroyRendertargets()
 		{
 			// Trash rendertargets
-			if(plotter != null) plotter.Dispose();
-			if(thingstex != null) thingstex.Dispose();
-			if(overlaytex != null) overlaytex.Dispose();
-			if(surfacetex != null) surfacetex.Dispose();
-			if(gridplotter != null) gridplotter.Dispose();
-			if(screenverts != null) screenverts.Dispose();
+			if (plotter != null) plotter.Dispose();
+			if (thingstex != null) thingstex.Dispose();
+			if (overlaytex != null) for(int i=0; i < overlaytex.Count; i++) { overlaytex[i].Dispose(); overlaytex[i] = null; } ;
+			if (surfacetex != null) surfacetex.Dispose();
+			if (gridplotter != null) gridplotter.Dispose();
+			if (screenverts != null) screenverts.Dispose();
 			thingstex = null;
             gridplotter = null;
 			screenverts = null;
@@ -369,13 +382,23 @@ namespace CodeImp.DoomBuilder.Rendering
 			plotter = new Plotter(windowsize.Width, windowsize.Height);
             gridplotter = new Plotter(windowsize.Width, windowsize.Height);
             thingstex = new Texture(windowsize.Width, windowsize.Height, TextureFormat.Rgba8);
-			overlaytex = new Texture(windowsize.Width, windowsize.Height, TextureFormat.Rgba8);
 			surfacetex = new Texture(windowsize.Width, windowsize.Height, TextureFormat.Rgba8);
-			
+
+			if (present == null)
+			{
+				overlaytex = new List<Texture>() { new Texture(windowsize.Width, windowsize.Height, TextureFormat.Rgba8) };
+			}
+			else
+			{
+				overlaytex = new List<Texture>();
+				for (int i = 0; i < present.layers.Count(l => l.layer == RendererLayer.Overlay); i++)
+					overlaytex.Add(new Texture(windowsize.Width, windowsize.Height, TextureFormat.Rgba8));
+			}
+
 			// Clear rendertargets
 			graphics.ClearTexture(General.Colors.Background.WithAlpha(0).ToColorValue(), thingstex);
-			graphics.ClearTexture(General.Colors.Background.WithAlpha(0).ToColorValue(), overlaytex);
-			
+			foreach(Texture t in overlaytex) graphics.ClearTexture(General.Colors.Background.WithAlpha(0).ToColorValue(), t);
+
 			// Create vertex buffers
 			screenverts = new VertexBuffer();
 			thingsvertices = new VertexBuffer();
@@ -731,7 +754,7 @@ namespace CodeImp.DoomBuilder.Rendering
 		}
 
 		// This begins a drawing session
-		public bool StartOverlay(bool clear)
+		public bool StartOverlay(bool clear, int layernum = 0)
 		{
 			if(renderlayer != RenderLayers.None)
 			{
@@ -745,10 +768,10 @@ namespace CodeImp.DoomBuilder.Rendering
 			renderlayer = RenderLayers.Overlay;
 			
 			// Rendertargets available?
-			if(overlaytex != null)
+			if(overlaytex != null && layernum >= 0 && layernum < overlaytex.Count)
 			{
 				// Set the rendertarget to the things texture
-                graphics.StartRendering(clear, General.Colors.Background.WithAlpha(0).ToColorValue(), overlaytex, false);
+                graphics.StartRendering(clear, General.Colors.Background.WithAlpha(0).ToColorValue(), overlaytex[layernum], false);
 
 				// Ready for rendering
 				UpdateTransformations();

--- a/Source/Plugins/SoundPropagationMode/BuilderPlug.cs
+++ b/Source/Plugins/SoundPropagationMode/BuilderPlug.cs
@@ -46,6 +46,7 @@ namespace CodeImp.DoomBuilder.SoundPropagationMode
 	{
 		public static readonly string SOUNDPROPAGATIONMODE = "soundpropagationmode";
 	}
+
 	public class BuilderPlug : Plug
 	{
 		#region ================== Constants

--- a/Source/Plugins/SoundPropagationMode/BuilderPlug.cs
+++ b/Source/Plugins/SoundPropagationMode/BuilderPlug.cs
@@ -41,6 +41,11 @@ namespace CodeImp.DoomBuilder.SoundPropagationMode
 	// Make sure the class is public, because only public classes can be seen
 	// by the core.
 	//
+
+	internal class ToastMessages
+	{
+		public static readonly string SOUNDPROPAGATIONMODE = "soundpropagationmode";
+	}
 	public class BuilderPlug : Plug
 	{
 		#region ================== Constants
@@ -170,6 +175,9 @@ namespace CodeImp.DoomBuilder.SoundPropagationMode
 
 			// Keep a static reference
             me = this;
+
+			// Register toasts
+			General.ToastManager.RegisterToast(ToastMessages.SOUNDPROPAGATIONMODE, "Sound propagation mode", "Toasts related to sound propagation mode");
 		}
 
 		public override void OnMapOpenBegin()

--- a/Source/Plugins/SoundPropagationMode/LeakFinder.cs
+++ b/Source/Plugins/SoundPropagationMode/LeakFinder.cs
@@ -21,7 +21,6 @@
 
 #endregion
 
-
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -64,6 +63,11 @@ namespace CodeImp.DoomBuilder.SoundPropagationMode
 			PopulateStartEndNeighbors(destination, End);
 		}
 
+		/// <summary>
+		/// Checks if the linedef is valid for passing sound.
+		/// </summary>
+		/// <param name="linedef">The linedef to check</param>
+		/// <returns>true if sound can travel through the linedef, false if not</returns>
 		private bool CheckLinedefValidity(Linedef linedef)
 		{
 			if (linedef.Back == null)
@@ -78,13 +82,17 @@ namespace CodeImp.DoomBuilder.SoundPropagationMode
 			return Sectors.Contains(linedef.Front.Sector) && Sectors.Contains(linedef.Back.Sector);
 		}
 
+		/// <summary>
+		/// Generates all nodes for the A* search algorithm.
+		/// </summary>
+		/// <param name="sectors">sectors to generate the nodes from</param>
 		private void GenerateNodes(HashSet<Sector> sectors)
 		{
+			// Create sound nodes for all valid linedefs in all given sectors
 			foreach(Sector s in sectors)
 			{
 				IEnumerable<Sidedef> sidedefs = s.Sidedefs.Where(sd => CheckLinedefValidity(sd.Line));
 
-				// Pass 1: create nodes
 				foreach(Sidedef sd in sidedefs)
 				{
 					if(!linedefs2nodes.ContainsKey(sd.Line))
@@ -95,8 +103,11 @@ namespace CodeImp.DoomBuilder.SoundPropagationMode
 				}
 			}
 
+			// We need the number of blocking nodes for safety checking
 			numblockingnodes = linedefs2nodes.Values.Count(n => n.IsBlocking);
 
+			// Set the neighbors for each node. The amount of interconnections can be very high in complex maps
+			// (for example there are nearly 3.9 million in Sunder map 20), so do it in parallel for speed
 			Parallel.ForEach(linedefs2nodes.Keys, ld =>
 			{
 				foreach (Sidedef sd in ld.Front.Sector.Sidedefs)
@@ -118,6 +129,11 @@ namespace CodeImp.DoomBuilder.SoundPropagationMode
 #endif
 		}
 
+		/// <summary>
+		/// Populates a sound node's neightbors to the linedefs of a sector. This is required for the start and end sound nodes.
+		/// </summary>
+		/// <param name="sector">The sector which linedef's sound nodes are used</param>
+		/// <param name="node">The sound node to add the neighbors to</param>
 		private void PopulateStartEndNeighbors(Sector sector, SoundNode node)
 		{
 			foreach(Sidedef sd in sector.Sidedefs)
@@ -130,16 +146,25 @@ namespace CodeImp.DoomBuilder.SoundPropagationMode
 			}
 		}
 
+		/// <summary>
+		/// Finds a sound leak between the start and end sound nodes.
+		/// </summary>
+		/// <returns>true if a leak was found, false if no leak was found</returns>
 		public bool FindLeak()
 		{
 			Finished = false;
 
+			// Basic A* search. The twist is that sound blocking lines: we can only pass through one of them,
+			// and A* doesn't backtrack, so it can fail to find a path even if there is a possible one. If that
+			// happens we set the sound blocking node we traveled through to be ignored, and start again. We repeat
+			// that until a path was found, or all blocking nodes are set to be ignored (which shouldn't happen)
 			while (true)
 			{
 				List<SoundNode> openset = new List<SoundNode>() { Start };
 
 				while (openset.Count > 0)
 				{
+					// Find the node with the lowest F score. Doing it that way seems to be fastest
 					SoundNode current = openset[0];
 					for (int i = 1; i < openset.Count; i++)
 					{
@@ -147,39 +172,49 @@ namespace CodeImp.DoomBuilder.SoundPropagationMode
 							current = openset[i];
 					}
 
+					// We're done if the node with the lowest F score is the end node
 					if (current == End)
 					{
 						Finished = true;
 						return true;
 					}
 
+					// Remove the current node from the open set
 					openset.Remove(current);
 
+					// Compute new values for the current node's neighbors
 					current.ProcessNeighbors(openset, Start);
 				}
 
+				// If we got here we didn't find a path. So we have to start over
+
 				int currentnumblockingnodes = 0;
 
+				// Reset all nodes
 				foreach(SoundNode sn in Nodes)
 				{
+					// Set the sound nodes that block sound and were visited (the G value was set to something) to be skipped.
 					if(sn.IsBlocking && sn.G != double.MaxValue)
 					{
 						sn.IsSkip = true;
 						currentnumblockingnodes++;
 					}
 
+					// We need to reset the sound node's G and F values
 					sn.Reset();
 				}
 
-				Start.G = 0.0;
-				Start.F = Start.H;
-
-				if(currentnumblockingnodes == numblockingnodes)
+				// All blocking sound nodes are being skipped, so no path is possible
+				if (currentnumblockingnodes == numblockingnodes)
 				{
 					Finished = true;
 
 					return false;
 				}
+
+				// Don't forget the reset the start node to its special values
+				Start.G = 0.0;
+				Start.F = Start.H;
 			}
 		}
 	}

--- a/Source/Plugins/SoundPropagationMode/LeakFinder.cs
+++ b/Source/Plugins/SoundPropagationMode/LeakFinder.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CodeImp.DoomBuilder.Map;
+
+namespace CodeImp.DoomBuilder.SoundPropagationMode
+{
+	internal class LeakFinder
+	{
+		public SoundNode Start { get; }
+		public SoundNode End { get; }
+		private SoundPropagationDomain Domain { get; }
+		public List<SoundNode> Nodes { get; }
+
+		private Dictionary<Linedef, SoundNode> linedefs2nodes;
+
+		public LeakFinder(Sector source, Sector destination, SoundPropagationDomain domain)
+		{
+			if (!(domain.Sectors.Contains(source) || domain.AdjacentSectors.Contains(source)) && !(domain.Sectors.Contains(destination) || domain.AdjacentSectors.Contains(destination)))
+				throw new ArgumentException("Sound propagation domain does not contain both the start and end sectors");
+
+			Domain = domain;
+
+			End = new SoundNode(destination.Labels[0].position);
+			Start = new SoundNode(source.Labels[0].position, End);
+
+			Nodes = new List<SoundNode>() { Start, End };
+
+			linedefs2nodes = new Dictionary<Linedef, SoundNode>();
+
+			GenerateNodes(domain.Sectors);
+			GenerateNodes(domain.AdjacentSectors);
+
+			PopulateStartEndNeighbors(source, Start);
+			PopulateStartEndNeighbors(destination, End);
+		}
+
+		private bool CheckLinedefValidity(Linedef linedef)
+		{
+			if (linedef.Back == null)
+				return false;
+
+			if (linedef.Front.Sector == linedef.Back.Sector)
+				return false;
+
+			if (SoundPropagationDomain.IsSoundBlockedByHeight(linedef))
+				return false;
+
+			bool front = Domain.Sectors.Contains(linedef.Back.Sector) || Domain.AdjacentSectors.Contains(linedef.Back.Sector);
+			bool back = Domain.Sectors.Contains(linedef.Back.Sector) || Domain.AdjacentSectors.Contains(linedef.Back.Sector);
+
+			return front && back;
+		}
+
+		private void GenerateNodes(HashSet<Sector> sectors)
+		{
+			foreach(Sector s in sectors)
+			{
+				IEnumerable<Sidedef> sidedefs = s.Sidedefs.Where(sd => CheckLinedefValidity(sd.Line));
+
+				// Pass 1: create nodes
+				foreach(Sidedef sd in sidedefs)
+				{
+					if(!linedefs2nodes.ContainsKey(sd.Line))
+					{
+						linedefs2nodes[sd.Line] = new SoundNode(sd.Line, End);
+						Nodes.Add(linedefs2nodes[sd.Line]);
+					}
+				}
+
+				// Pass 2: populate neighbors
+				foreach(Sidedef sd1 in sidedefs)
+				{
+					foreach(Sidedef sd2 in sidedefs)
+					{
+						if (sd1 != sd2)
+							linedefs2nodes[sd1.Line].Neighbors.Add(linedefs2nodes[sd2.Line]);
+					}
+				}
+			}
+		}
+
+		private void PopulateStartEndNeighbors(Sector sector, SoundNode node)
+		{
+			foreach(Sidedef sd in sector.Sidedefs)
+			{
+				if(CheckLinedefValidity(sd.Line) && linedefs2nodes.ContainsKey(sd.Line))
+				{
+					node.Neighbors.Add(linedefs2nodes[sd.Line]);
+					linedefs2nodes[sd.Line].Neighbors.Add(node);
+				}
+			}
+		}
+	}
+}

--- a/Source/Plugins/SoundPropagationMode/LeakFinder.cs
+++ b/Source/Plugins/SoundPropagationMode/LeakFinder.cs
@@ -16,6 +16,7 @@ namespace CodeImp.DoomBuilder.SoundPropagationMode
 		public SoundNode End { get; }
 		public List<SoundNode> Nodes { get; }
 		public HashSet<Sector> Sectors { get; }
+		public bool Finished { get; internal set; }
 
 		private ConcurrentDictionary<Linedef, SoundNode> linedefs2nodes;
 		private int numblockingnodes;
@@ -28,6 +29,8 @@ namespace CodeImp.DoomBuilder.SoundPropagationMode
 			End = new SoundNode(destinationposition);
 			Start = new SoundNode(sourceposition, End) { G = 0 };
 			Sectors = sectors;
+
+			Finished = false;
 
 			Nodes = new List<SoundNode>() { Start, End };
 
@@ -134,6 +137,7 @@ namespace CodeImp.DoomBuilder.SoundPropagationMode
 		public bool FindLeak()
 		{
 			Stopwatch sw = Stopwatch.StartNew();
+			Finished = false;
 
 			while (true)
 			{
@@ -152,6 +156,7 @@ namespace CodeImp.DoomBuilder.SoundPropagationMode
 					{
 						sw.Stop();
 						Console.WriteLine($"FindLeak took {sw.ElapsedMilliseconds} ms");
+						Finished = true;
 						return true;
 					}
 
@@ -180,6 +185,8 @@ namespace CodeImp.DoomBuilder.SoundPropagationMode
 				{
 					sw.Stop();
 					Console.WriteLine($"FindLeak took {sw.ElapsedMilliseconds} ms");
+
+					Finished = true;
 
 					return false;
 				}

--- a/Source/Plugins/SoundPropagationMode/Properties/Resources.Designer.cs
+++ b/Source/Plugins/SoundPropagationMode/Properties/Resources.Designer.cs
@@ -73,6 +73,16 @@ namespace CodeImp.DoomBuilder.SoundPropagationMode.Properties {
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
+        internal static System.Drawing.Bitmap SoundPropagationIcon {
+            get {
+                object obj = ResourceManager.GetObject("SoundPropagationIcon", resourceCulture);
+                return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Bitmap.
+        /// </summary>
         internal static System.Drawing.Bitmap Status0 {
             get {
                 object obj = ResourceManager.GetObject("Status0", resourceCulture);

--- a/Source/Plugins/SoundPropagationMode/Properties/Resources.resx
+++ b/Source/Plugins/SoundPropagationMode/Properties/Resources.resx
@@ -112,14 +112,17 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="ColorManagement" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\ColorManagement.png;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="SoundPropagationIcon" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\soundpropagationicon.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="Status0" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\Status0.png;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>

--- a/Source/Plugins/SoundPropagationMode/Properties/Resources.resx
+++ b/Source/Plugins/SoundPropagationMode/Properties/Resources.resx
@@ -122,7 +122,7 @@
     <value>..\Resources\ColorManagement.png;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="SoundPropagationIcon" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\soundpropagationicon.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>..\Resources\SoundPropagationIcon.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="Status0" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\Status0.png;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>

--- a/Source/Plugins/SoundPropagationMode/Resources/Actions.cfg
+++ b/Source/Plugins/SoundPropagationMode/Resources/Actions.cfg
@@ -54,3 +54,25 @@ soundpropagationcolorconfiguration
 	allowmouse = true;
 	allowscroll = true;
 }
+
+setleakfinderstart
+{
+	title = "Set leak finder start sector";
+	category = "soundpropagationmode";
+	description = "Sets the starting sector for the sound leak finder";
+	allowkeys = true;
+	allowmouse = true;
+	allowscroll = true;
+
+}
+
+setleakfinderend
+{
+	title = "Set leak finder end sector";
+	category = "soundpropagationmode";
+	description = "Sets the ending sector for the sound leak finder";
+	allowkeys = true;
+	allowmouse = true;
+	allowscroll = true;
+
+}

--- a/Source/Plugins/SoundPropagationMode/Resources/Actions.cfg
+++ b/Source/Plugins/SoundPropagationMode/Resources/Actions.cfg
@@ -63,7 +63,7 @@ setleakfinderstart
 	allowkeys = true;
 	allowmouse = true;
 	allowscroll = true;
-
+	default = 65619; // Shift+S
 }
 
 setleakfinderend
@@ -74,5 +74,5 @@ setleakfinderend
 	allowkeys = true;
 	allowmouse = true;
 	allowscroll = true;
-
+	default = 65605; // Shift+E
 }

--- a/Source/Plugins/SoundPropagationMode/SoundNode.cs
+++ b/Source/Plugins/SoundPropagationMode/SoundNode.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CodeImp.DoomBuilder.Geometry;
+using CodeImp.DoomBuilder.Map;
+using CodeImp.DoomBuilder.Rendering;
+
+namespace CodeImp.DoomBuilder.SoundPropagationMode
+{
+	internal class SoundNode
+	{
+		public Vector2D Position { get; set; }
+		public List<SoundNode> Neighbors { get; set; }
+		public SoundNode From { get; set; }
+		public double G { get; set; }
+		public double H { get; }
+		public double F => G + H;
+		public bool isBlocking;
+		public bool skip;
+
+		public SoundNode(Vector2D position)
+		{
+			Position = position;
+			G = double.MaxValue;
+			H = double.MaxValue;
+			isBlocking = false;
+			skip = false;
+			Neighbors = new List<SoundNode>();
+		}
+
+		public SoundNode(Vector2D position, SoundNode destination): this(position)
+		{
+			H = Vector2D.Distance(Position, destination.Position);
+		}
+
+		public SoundNode(Linedef linedef, SoundNode destination) : this(linedef.Line.GetCoordinatesAt(0.5), destination)
+		{
+			isBlocking = General.Map.UDMF ? linedef.IsFlagSet("blocksound") : linedef.IsFlagSet("64");
+		}
+
+		internal void Render(IRenderer2D renderer)
+		{
+			RectangleF rectangle = new RectangleF((float)(Position.x - 10), (float)(Position.y - 10), 20, 20);
+			renderer.RenderRectangleFilled(rectangle, PixelColor.FromColor(Color.Red), true);
+
+			foreach (SoundNode sn in Neighbors)
+				renderer.RenderLine(Position, sn.Position, 1.0f, PixelColor.FromColor(Color.Red), true);
+		}
+
+	}
+}

--- a/Source/Plugins/SoundPropagationMode/SoundNode.cs
+++ b/Source/Plugins/SoundPropagationMode/SoundNode.cs
@@ -40,7 +40,7 @@ namespace CodeImp.DoomBuilder.SoundPropagationMode
 
 		public SoundNode(Linedef linedef, SoundNode destination) : this(linedef.Line.GetCoordinatesAt(0.5), destination)
 		{
-			IsBlocking = General.Map.UDMF ? linedef.IsFlagSet("blocksound") : linedef.IsFlagSet("64");
+			IsBlocking = linedef.IsFlagSet(SoundPropagationMode.BlockSoundFlag);
 		}
 
 		//public void ProcessNeighbors(HashSet<SoundNode> openset)

--- a/Source/Plugins/SoundPropagationMode/SoundNode.cs
+++ b/Source/Plugins/SoundPropagationMode/SoundNode.cs
@@ -1,10 +1,28 @@
-﻿using System;
-using System.Collections.Concurrent;
+﻿#region ================== Copyright (c) 2023 Boris Iwanski
+
+/*
+ * This program is free software: you can redistribute it and/or modify
+ *
+ * it under the terms of the GNU General Public License as published by
+ * 
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * 
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.If not, see<http://www.gnu.org/licenses/>.
+ */
+
+#endregion
+
 using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using CodeImp.DoomBuilder.Geometry;
 using CodeImp.DoomBuilder.Map;
 using CodeImp.DoomBuilder.Rendering;
@@ -94,7 +112,7 @@ namespace CodeImp.DoomBuilder.SoundPropagationMode
 				renderer.RenderLine(Position, sn.Position, 1.0f, PixelColor.FromColor(Color.Purple), true);
 		}
 
-		internal void RenderPath(IRenderer2D renderer, int dashoffset)
+		internal void RenderPath(IRenderer2D renderer)
 		{
 			SoundNode current = this;
 
@@ -112,6 +130,5 @@ namespace CodeImp.DoomBuilder.SoundPropagationMode
 				current = current.From;
 			}
 		}
-
 	}
 }

--- a/Source/Plugins/SoundPropagationMode/SoundNode.cs
+++ b/Source/Plugins/SoundPropagationMode/SoundNode.cs
@@ -100,8 +100,11 @@ namespace CodeImp.DoomBuilder.SoundPropagationMode
 
 			while(current != null)
 			{
-				RectangleF rectangle = new RectangleF((float)(current.Position.x - 4 / renderer.Scale), (float)(current.Position.y - 4 / renderer.Scale), 8 / renderer.Scale, 8 / renderer.Scale);
-				renderer.RenderRectangleFilled(rectangle, PixelColor.FromColor(Color.Red), true);
+				if (current != this && current.From != null)
+				{
+					RectangleF rectangle = new RectangleF((float)(current.Position.x - 4 / renderer.Scale), (float)(current.Position.y - 4 / renderer.Scale), 8 / renderer.Scale, 8 / renderer.Scale);
+					renderer.RenderRectangleFilled(rectangle, PixelColor.FromColor(Color.Red), true);
+				}
 
 				if(current.From != null)
 					renderer.RenderLine(current.Position, current.From.Position, 1.0f, PixelColor.FromColor(Color.Red), true);

--- a/Source/Plugins/SoundPropagationMode/SoundPropagation.csproj
+++ b/Source/Plugins/SoundPropagationMode/SoundPropagation.csproj
@@ -118,6 +118,7 @@
     <Compile Include="Interface\SoundEnvironmentPanel.Designer.cs">
       <DependentUpon>SoundEnvironmentPanel.cs</DependentUpon>
     </Compile>
+    <Compile Include="LeakFinder.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
@@ -125,6 +126,7 @@
     </Compile>
     <Compile Include="SoundEnvironment.cs" />
     <Compile Include="SoundEnvironmentMode.cs" />
+    <Compile Include="SoundNode.cs" />
     <Compile Include="SoundPropagationDomain.cs" />
     <Compile Include="Windows\ColorConfiguration.cs">
       <SubType>Form</SubType>

--- a/Source/Plugins/SoundPropagationMode/SoundPropagation.csproj
+++ b/Source/Plugins/SoundPropagationMode/SoundPropagation.csproj
@@ -195,6 +195,9 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\Hints.cfg" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Source/Plugins/SoundPropagationMode/SoundPropagationDomain.cs
+++ b/Source/Plugins/SoundPropagationMode/SoundPropagationDomain.cs
@@ -108,7 +108,7 @@ namespace CodeImp.DoomBuilder.SoundPropagationMode
 			}
 		}
 
-		private static bool IsSoundBlockedByHeight(Linedef ld)
+		public static bool IsSoundBlockedByHeight(Linedef ld)
 		{
 			if(ld.Back == null || ld.Front == null) return false;
 

--- a/Source/Plugins/SoundPropagationMode/SoundPropagationMode.cs
+++ b/Source/Plugins/SoundPropagationMode/SoundPropagationMode.cs
@@ -226,9 +226,10 @@ namespace CodeImp.DoomBuilder.SoundPropagationMode
 			CustomPresentation presentation = new CustomPresentation();
 			presentation.AddLayer(new PresentLayer(RendererLayer.Background, BlendingMode.Mask, General.Settings.BackgroundAlpha));
 			presentation.AddLayer(new PresentLayer(RendererLayer.Grid, BlendingMode.Mask));
-			presentation.AddLayer(new PresentLayer(RendererLayer.Overlay, BlendingMode.Alpha, 1.0f, true));
+			presentation.AddLayer(new PresentLayer(RendererLayer.Overlay, BlendingMode.Alpha, 1.0f, true)); // First overlay (0)
 			presentation.AddLayer(new PresentLayer(RendererLayer.Things, BlendingMode.Alpha, 1.0f));
 			presentation.AddLayer(new PresentLayer(RendererLayer.Geometry, BlendingMode.Alpha, 1.0f, true));
+			presentation.AddLayer(new PresentLayer(RendererLayer.Overlay, BlendingMode.Alpha, 1.0f, true)); // Second overlay (1)
 			renderer.SetPresentation(presentation);
 
 			leakstartlabel = new TextLabel
@@ -288,6 +289,10 @@ namespace CodeImp.DoomBuilder.SoundPropagationMode
 
 			PixelColor doublesided = General.Colors.Linedefs.WithAlpha(General.Settings.DoubleSidedAlphaByte);
 
+			// We don't care for the actualy surfaces, but without this the render targets will not be recreated
+			// when the window is resized
+			renderer.RedrawSurface();
+
 			// Render lines and vertices
 			if (renderer.StartPlotter(true))
 			{
@@ -336,6 +341,7 @@ namespace CodeImp.DoomBuilder.SoundPropagationMode
 				renderer.Finish();
 			}
 
+			// The sound propagation domain overlay
 			if (renderer.StartOverlay(true))
 			{
 				// Render highlighted domain and domains adjacent to it
@@ -365,6 +371,12 @@ namespace CodeImp.DoomBuilder.SoundPropagationMode
 						renderer.RenderHighlight(spd.Level1Geometry, spd.Color);
 				}
 
+				renderer.Finish();
+			}
+
+			// The sound leak overlay. This is done so that the path and labels are drawn at the very top
+			if (renderer.StartOverlay(true, 1))
+			{
 				if (leakfinder != null && leakfinder.Finished)
 					leakfinder.End.RenderPath(renderer);
 

--- a/Source/Plugins/SoundPropagationMode/SoundPropagationMode.cs
+++ b/Source/Plugins/SoundPropagationMode/SoundPropagationMode.cs
@@ -25,6 +25,7 @@ using CodeImp.DoomBuilder.Map;
 using CodeImp.DoomBuilder.Rendering;
 using CodeImp.DoomBuilder.Editing;
 using CodeImp.DoomBuilder.Actions;
+using System.Linq;
 
 #endregion
 
@@ -52,6 +53,7 @@ namespace CodeImp.DoomBuilder.SoundPropagationMode
 		private List<Thing> huntingThings;
 		private List<SoundPropagationDomain> propagationdomains;
 		private Dictionary<Sector, SoundPropagationDomain> sector2domain;
+		private LeakFinder leakfinder;
 
 		// The blockmap makes is used to make finding lines faster
 		BlockMap<BlockEntry> blockmap;
@@ -225,6 +227,8 @@ namespace CodeImp.DoomBuilder.SoundPropagationMode
 
 			UpdateSoundPropagation();
 			General.Interface.RedrawDisplay();
+
+			leakfinder = new LeakFinder(General.Map.Map.Sectors.First(), General.Map.Map.Sectors.Last(), propagationdomains[0]);
 		}
 
 		// Mode disengages
@@ -310,6 +314,10 @@ namespace CodeImp.DoomBuilder.SoundPropagationMode
 					foreach(SoundPropagationDomain spd in propagationdomains)
 						renderer.RenderHighlight(spd.Level1Geometry, spd.Color);
 				}
+
+				if (leakfinder != null)
+					foreach (SoundNode sn in leakfinder.Nodes)
+						sn.Render(renderer);
 
 				renderer.Finish();
 			}

--- a/Source/Plugins/SoundPropagationMode/SoundPropagationMono.csproj
+++ b/Source/Plugins/SoundPropagationMode/SoundPropagationMono.csproj
@@ -116,6 +116,7 @@
     <Compile Include="Interface\SoundEnvironmentPanel.Designer.cs">
       <DependentUpon>SoundEnvironmentPanel.cs</DependentUpon>
     </Compile>
+    <Compile Include="LeakFinder.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
@@ -123,6 +124,7 @@
     </Compile>
     <Compile Include="SoundEnvironment.cs" />
     <Compile Include="SoundEnvironmentMode.cs" />
+    <Compile Include="SoundNode.cs" />
     <Compile Include="SoundPropagationDomain.cs" />
     <Compile Include="Windows\ColorConfiguration.cs">
       <SubType>Form</SubType>

--- a/Source/Plugins/SoundPropagationMode/SoundPropagationMono.csproj
+++ b/Source/Plugins/SoundPropagationMode/SoundPropagationMono.csproj
@@ -193,6 +193,9 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Resources\Hints.cfg" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
In Sound Propagation Mode you can set the start (default: Shift+S) and end (default: Shift+E) sectors between which a path the sound can travel will be found and displayed.