### PR TITLE
Update things filter when clone-dragging things

### DIFF
--- a/Source/Plugins/BuilderModes/ClassicModes/ThingsMode.cs
+++ b/Source/Plugins/BuilderModes/ClassicModes/ThingsMode.cs
@@ -809,6 +809,16 @@ namespace CodeImp.DoomBuilder.BuilderModes
 
 								// All the cloned things are now the things we want to drag
 								dragthings = clonedthings;
+
+								// Update things filter
+								General.Map.ThingsFilter.Update();
+								General.Interface.RefreshInfo();
+
+								//mxd. Update helper lines
+								UpdateHelperObjects();
+
+								// Redraw
+								General.Interface.RedrawDisplay();
 							}
 						}
 


### PR DESCRIPTION
When a things filter is active, clone-dragged things could get filtered out when they weren't supposed to be.