### PR TITLE
Point Thing at Cursor: check for a thing's FixedRotation setting rather than its category's Arrow setting

### DIFF
--- a/Source/Plugins/BuilderModes/ClassicModes/ThingsMode.cs
+++ b/Source/Plugins/BuilderModes/ClassicModes/ThingsMode.cs
@@ -1474,7 +1474,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 				foreach(Thing t in selected) 
 				{
 					ThingTypeInfo info = General.Map.Data.GetThingInfo(t.Type);
-					if(info == null || info.Category == null || info.Category.Arrow == 0)
+					if(info == null || info.FixedRotation == true)
 						continue;
 
 					int newangle = Angle2D.RealToDoom(Vector2D.GetAngle(mousemappos, t.Position) + Angle2D.PI);
@@ -1488,7 +1488,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 				foreach(Thing t in selected) 
 				{
 					ThingTypeInfo info = General.Map.Data.GetThingInfo(t.Type);
-					if(info == null || info.Category == null || info.Category.Arrow == 0)
+					if(info == null || info.FixedRotation == true)
 						continue;
 
 					int newangle = Angle2D.RealToDoom(Vector2D.GetAngle(mousemappos, t.Position));


### PR DESCRIPTION
The previous check could cause issues: if a configuration had a thing with the Arrow setting, inside of a category without it, it would be skipped despite angle changes (supposedly) being relevant for that thing.