### PR TITLE
update builder.sh to automatically cd into where the Builder.exe is

### DIFF
--- a/builder.sh
+++ b/builder.sh
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
+cd "$(dirname "$0")"
 mono Builder.exe


### PR DESCRIPTION
if you run `builder` while not in the Build directory, it doesn't run because it can't find the file in the current directory. this should fix it.