### PR TITLE
Fix Buggy flood select in Visual Mode

### DIFF
--- a/Source/Plugins/BuilderModes/General/BuilderPlug.cs
+++ b/Source/Plugins/BuilderModes/General/BuilderPlug.cs
@@ -150,6 +150,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		private bool useoppositesmartpivothandle;
 		private bool selectchangedafterundoredo;
 		private bool selectadjacentvisualvertexslopehandles;
+		private bool usebuggyfloodselect;
 
 		#endregion
 
@@ -211,6 +212,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		public bool UseOppositeSmartPivotHandle { get { return useoppositesmartpivothandle; } internal set { useoppositesmartpivothandle = value; } }
 		public bool SelectChangedafterUndoRedo { get { return selectchangedafterundoredo; } internal set { selectchangedafterundoredo = value; } }
 		public bool SelectAdjacentVisualVertexSlopeHandles { get { return selectadjacentvisualvertexslopehandles; } internal set { selectadjacentvisualvertexslopehandles = value; } }
+		public bool UseBuggyFloodSelect { get { return usebuggyfloodselect; } internal set { usebuggyfloodselect = value; } }
 
 		//mxd. "Make Door" action persistent settings
 		internal MakeDoorSettings MakeDoor;
@@ -324,6 +326,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 			eventlinedistinctcolors = General.Settings.ReadPluginSetting("eventlinedistinctcolors", true);
 			useoppositesmartpivothandle = General.Settings.ReadPluginSetting("useoppositesmartpivothandle", true);
 			selectchangedafterundoredo = General.Settings.ReadPluginSetting("selectchangedafterundoredo", false);
+			usebuggyfloodselect = General.Settings.ReadPluginSetting("usebuggyfloodselect", false);
 		}
 
 		//mxd. Load settings, which can be changed via UI

--- a/Source/Plugins/BuilderModes/Interface/PreferencesForm.Designer.cs
+++ b/Source/Plugins/BuilderModes/Interface/PreferencesForm.Designer.cs
@@ -80,6 +80,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 			this.label10 = new System.Windows.Forms.Label();
 			this.label1 = new System.Windows.Forms.Label();
 			this.heightbysidedef = new System.Windows.Forms.ComboBox();
+			this.usebuggyfloodselect = new System.Windows.Forms.CheckBox();
 			this.tabs.SuspendLayout();
 			this.taboptions.SuspendLayout();
 			this.groupBox5.SuspendLayout();
@@ -275,6 +276,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 			// 
 			// groupBox3
 			// 
+			this.groupBox3.Controls.Add(this.usebuggyfloodselect);
 			this.groupBox3.Controls.Add(this.selectafterundoredo);
 			this.groupBox3.Controls.Add(this.useoppositesmartpivothandle);
 			this.groupBox3.Controls.Add(this.additivepaintselect);
@@ -291,7 +293,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 			this.groupBox3.Controls.Add(this.additiveselect);
 			this.groupBox3.Location = new System.Drawing.Point(284, 139);
 			this.groupBox3.Name = "groupBox3";
-			this.groupBox3.Size = new System.Drawing.Size(379, 360);
+			this.groupBox3.Size = new System.Drawing.Size(379, 390);
 			this.groupBox3.TabIndex = 3;
 			this.groupBox3.TabStop = false;
 			this.groupBox3.Text = " Options ";
@@ -732,6 +734,16 @@ namespace CodeImp.DoomBuilder.BuilderModes
 			this.heightbysidedef.Size = new System.Drawing.Size(309, 21);
 			this.heightbysidedef.TabIndex = 0;
 			// 
+			// usebuggyfloodselect
+			// 
+			this.usebuggyfloodselect.AutoSize = true;
+			this.usebuggyfloodselect.Location = new System.Drawing.Point(13, 359);
+			this.usebuggyfloodselect.Name = "usebuggyfloodselect";
+			this.usebuggyfloodselect.Size = new System.Drawing.Size(206, 17);
+			this.usebuggyfloodselect.TabIndex = 13;
+			this.usebuggyfloodselect.Text = "Use buggy flood select in Visual Mode";
+			this.usebuggyfloodselect.UseVisualStyleBackColor = true;
+			// 
 			// PreferencesForm
 			// 
 			this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
@@ -812,5 +824,6 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		private System.Windows.Forms.ComboBox eventlinelabelstyle;
 		private System.Windows.Forms.CheckBox useoppositesmartpivothandle;
 		private System.Windows.Forms.CheckBox selectafterundoredo;
+		private System.Windows.Forms.CheckBox usebuggyfloodselect;
 	}
 }

--- a/Source/Plugins/BuilderModes/Interface/PreferencesForm.cs
+++ b/Source/Plugins/BuilderModes/Interface/PreferencesForm.cs
@@ -69,6 +69,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 			eventlinelabelstyle.SelectedIndex = General.Settings.ReadPluginSetting("eventlinelabelstyle", 2);
 			useoppositesmartpivothandle.Checked = General.Settings.ReadPluginSetting("useoppositesmartpivothandle", true);
 			selectafterundoredo.Checked = General.Settings.ReadPluginSetting("selectchangedafterundoredo", false);
+			usebuggyfloodselect.Checked = General.Settings.ReadPluginSetting("usebuggyfloodselect", false);
 		}
 
 		#endregion
@@ -101,6 +102,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 			General.Settings.WritePluginSetting("eventlinelabelstyle", eventlinelabelstyle.SelectedIndex);
 			General.Settings.WritePluginSetting("useoppositesmartpivothandle", useoppositesmartpivothandle.Checked);
 			General.Settings.WritePluginSetting("selectchangedafterundoredo", selectafterundoredo.Checked);
+			General.Settings.WritePluginSetting("usebuggyfloodselect", usebuggyfloodselect.Checked);
 			General.Settings.SwitchViewModes = switchviewmodes.Checked; //mxd
 			General.Settings.SplitLineBehavior = (SplitLineBehavior)splitbehavior.SelectedIndex;//mxd
 			

--- a/Source/Plugins/BuilderModes/VisualModes/BaseVisualGeometrySector.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/BaseVisualGeometrySector.cs
@@ -98,7 +98,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		// This changes the height
 		protected abstract void ChangeHeight(int amount);
 		protected abstract void ChangeTextureScale(int incrementX, int incrementY); //mxd
-		public virtual void SelectNeighbours(bool select, bool withSameTexture, bool withSameHeight) { } //mxd
+		public virtual void SelectNeighbours(bool select, bool withSameTexture, bool withSameHeight, bool stopatselected) { } //mxd
 
 		//mxd
 		override public void PerformAutoSelection()

--- a/Source/Plugins/BuilderModes/VisualModes/BaseVisualGeometrySidedef.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/BaseVisualGeometrySidedef.cs
@@ -585,12 +585,12 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		}
 
 		//mxd
-        public void SelectNeighbours(bool select, bool matchtexture, bool matchheight)
+        public void SelectNeighbours(bool select, bool matchtexture, bool matchheight, bool stopatselected)
         {
-            SelectNeighbours(select, matchtexture, matchheight, true, true);
+            SelectNeighbours(select, matchtexture, matchheight, true, true, stopatselected);
         }
 
-		private void SelectNeighbours(bool select, bool matchtexture, bool matchheight, bool clearlinedefs, bool forward)
+		private void SelectNeighbours(bool select, bool matchtexture, bool matchheight, bool clearlinedefs, bool forward, bool stopatselected)
 		{
 			if(Sidedef.Sector == null || Triangles < 1 || (!matchtexture && !matchheight)) return;
 
@@ -618,21 +618,21 @@ namespace CodeImp.DoomBuilder.BuilderModes
             if (forward)
             {
                 v = Sidedef.IsFront ? Sidedef.Line.End : Sidedef.Line.Start;
-                SelectNeighbourLines(v.Linedefs, v, rect, select, matchtexture, matchheight, true);
+                SelectNeighbourLines(v.Linedefs, v, rect, select, matchtexture, matchheight, true, stopatselected);
                 v = Sidedef.IsFront ? Sidedef.Line.Start : Sidedef.Line.End;
-                SelectNeighbourLines(v.Linedefs, v, rect, select, matchtexture, matchheight, false);
+                SelectNeighbourLines(v.Linedefs, v, rect, select, matchtexture, matchheight, false, stopatselected);
             }
             else
             {
                 v = Sidedef.IsFront ? Sidedef.Line.Start : Sidedef.Line.End;
-                SelectNeighbourLines(v.Linedefs, v, rect, select, matchtexture, matchheight, false);
+                SelectNeighbourLines(v.Linedefs, v, rect, select, matchtexture, matchheight, false, stopatselected);
                 v = Sidedef.IsFront ? Sidedef.Line.End : Sidedef.Line.Start;
-                SelectNeighbourLines(v.Linedefs, v, rect, select, matchtexture, matchheight, true);
+                SelectNeighbourLines(v.Linedefs, v, rect, select, matchtexture, matchheight, true, stopatselected);
             }
 		}
 
 		//mxd
-		private void SelectNeighbourLines(IEnumerable<Linedef> lines, Vertex v, Rectangle sourcerect, bool select, bool matchtexture, bool matchheight, bool forward)
+		private void SelectNeighbourLines(IEnumerable<Linedef> lines, Vertex v, Rectangle sourcerect, bool select, bool matchtexture, bool matchheight, bool forward, bool stopatselected)
 		{
 			foreach(Linedef line in lines)
 			{
@@ -650,12 +650,12 @@ namespace CodeImp.DoomBuilder.BuilderModes
                 if (next == null || next.Sector == null)
                     continue;
 
-                SelectNeighbourSideParts(next, sourcerect, select, matchtexture, matchheight, forward);
+                SelectNeighbourSideParts(next, sourcerect, select, matchtexture, matchheight, forward, stopatselected);
 			}
 		}
 
 		//mxd
-		private void SelectNeighbourSideParts(Sidedef side, Rectangle sourcerect, bool select, bool matchtexture, bool matchheight, bool forward)
+		private void SelectNeighbourSideParts(Sidedef side, Rectangle sourcerect, bool select, bool matchtexture, bool matchheight, bool forward, bool stopatselected)
 		{
             if (side.Line.Marked)
                 return;
@@ -664,30 +664,30 @@ namespace CodeImp.DoomBuilder.BuilderModes
 			if(s != null)
 			{
 				VisualSidedefParts parts = s.GetSidedefParts(side);
-				SelectNeighbourSidePart(parts.lower, sourcerect, select, matchtexture, matchheight, forward);
-				SelectNeighbourSidePart(parts.middlesingle, sourcerect, select, matchtexture, matchheight, forward);
-				SelectNeighbourSidePart(parts.middledouble, sourcerect, select, matchtexture, matchheight, forward);
-				SelectNeighbourSidePart(parts.upper, sourcerect, select, matchtexture, matchheight, forward);
+				SelectNeighbourSidePart(parts.lower, sourcerect, select, matchtexture, matchheight, forward, stopatselected);
+				SelectNeighbourSidePart(parts.middlesingle, sourcerect, select, matchtexture, matchheight, forward, stopatselected);
+				SelectNeighbourSidePart(parts.middledouble, sourcerect, select, matchtexture, matchheight, forward, stopatselected);
+				SelectNeighbourSidePart(parts.upper, sourcerect, select, matchtexture, matchheight, forward, stopatselected);
 
 				if(parts.middle3d != null)
 				{
 					foreach(VisualMiddle3D middle3D in parts.middle3d)
-						SelectNeighbourSidePart(middle3D, sourcerect, select, matchtexture, matchheight, forward);
+						SelectNeighbourSidePart(middle3D, sourcerect, select, matchtexture, matchheight, forward, stopatselected);
 				}
 			}
 		}
 
 		//mxd
-		private void SelectNeighbourSidePart(BaseVisualGeometrySidedef visualside, Rectangle sourcerect, bool select, bool matchtexture, bool matchheight, bool forward)
+		private void SelectNeighbourSidePart(BaseVisualGeometrySidedef visualside, Rectangle sourcerect, bool select, bool matchtexture, bool matchheight, bool forward, bool stopatselected)
 		{
-			if(visualside != null && visualside.Triangles > 0 && visualside.Selected != select)
+			if (visualside != null && visualside.Triangles > 0 && !visualside.Sidedef.Marked && (!stopatselected || (visualside.Selected != select)))
 			{
 				Rectangle r = BuilderModesTools.GetSidedefPartSize(visualside);
 				if(r.Width == 0 || r.Height == 0) return;
 				if((!matchtexture || (visualside.Texture == Texture && r.IntersectsWith(sourcerect))) &&
 				   (!matchheight || (sourcerect.Height == r.Height && sourcerect.Y == r.Y)))
 				{
-					visualside.SelectNeighbours(select, matchtexture, matchheight, false, forward);
+					visualside.SelectNeighbours(select, matchtexture, matchheight, false, forward, stopatselected);
 				}
 			}
 		}

--- a/Source/Plugins/BuilderModes/VisualModes/BaseVisualMode.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/BaseVisualMode.cs
@@ -2662,17 +2662,17 @@ namespace CodeImp.DoomBuilder.BuilderModes
 			//mxd
 			if((General.Interface.ShiftState || General.Interface.CtrlState) && selectedobjects.Count > 0) 
 			{
-				if(General.Interface.AltState)
+				if (General.Interface.AltState || !BuilderPlug.Me.UseBuggyFloodSelect)
 				{
-					target.SelectNeighbours(target.Selected, General.Interface.ShiftState, General.Interface.CtrlState);
+					target.SelectNeighbours(target.Selected, General.Interface.ShiftState, General.Interface.CtrlState, General.Interface.AltState);
 				}
 				else
 				{
 					IVisualEventReceiver[] selection = new IVisualEventReceiver[selectedobjects.Count];
 					selectedobjects.CopyTo(selection);
-					
-					foreach(IVisualEventReceiver obj in selection)
-						obj.SelectNeighbours(target.Selected, General.Interface.ShiftState, General.Interface.CtrlState);
+
+					foreach (IVisualEventReceiver obj in selection)
+						obj.SelectNeighbours(target.Selected, General.Interface.ShiftState, General.Interface.CtrlState, false);
 				}
 			}
 

--- a/Source/Plugins/BuilderModes/VisualModes/BaseVisualSlope.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/BaseVisualSlope.cs
@@ -127,7 +127,7 @@ namespace CodeImp.DoomBuilder.VisualModes
 		public void ApplyTexture(string texture) { }
 		public void ApplyUpperUnpegged(bool set) { }
 		public void ApplyLowerUnpegged(bool set) { }
-		public void SelectNeighbours(bool select, bool withSameTexture, bool withSameHeight) { } //mxd
+		public void SelectNeighbours(bool select, bool withSameTexture, bool withSameHeight, bool stopatselected) { } //mxd
 		public virtual void OnPaintSelectEnd() { } // biwa
 		public void OnChangeScale(int x, int y) { }
 		public void OnResetTextureOffset() { }

--- a/Source/Plugins/BuilderModes/VisualModes/BaseVisualThing.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/BaseVisualThing.cs
@@ -673,7 +673,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		public void ApplyTexture(string texture) { }
 		public void ApplyUpperUnpegged(bool set) { }
 		public void ApplyLowerUnpegged(bool set) { }
-		public void SelectNeighbours(bool select, bool withSameTexture, bool withSameHeight) { } //mxd
+		public void SelectNeighbours(bool select, bool withSameTexture, bool withSameHeight, bool stopatselected) { } //mxd
 		public virtual void OnPaintSelectEnd() { } // biwa
 
 		// Return texture name

--- a/Source/Plugins/BuilderModes/VisualModes/BaseVisualVertex.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/BaseVisualVertex.cs
@@ -261,7 +261,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		public void ApplyUpperUnpegged(bool set) { }
 		public void ApplyLowerUnpegged(bool set) { }
 		public string GetTextureName() { return ""; }
-		public void SelectNeighbours(bool select, bool withSameTexture, bool withSameHeight) { } //mxd
+		public void SelectNeighbours(bool select, bool withSameTexture, bool withSameHeight, bool stopatselected) { } //mxd
 		public virtual void OnPaintSelectBegin() { } // biwa
 		public virtual void OnPaintSelectEnd() { } // biwa
 

--- a/Source/Plugins/BuilderModes/VisualModes/IVisualEventReceiver.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/IVisualEventReceiver.cs
@@ -64,6 +64,6 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		
 		// Other methods
 		string GetTextureName();
-		void SelectNeighbours(bool select, bool matchtexture, bool matchheight); //mxd
+		void SelectNeighbours(bool select, bool matchtexture, bool matchheight, bool stopatselected); //mxd
 	}
 }

--- a/Source/Plugins/BuilderModes/VisualModes/NullVisualEventReceiver.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/NullVisualEventReceiver.cs
@@ -59,6 +59,6 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		public void ApplyUpperUnpegged(bool set) { }
 		public void ApplyLowerUnpegged(bool set) { }
 		public string GetTextureName() { return "";	}
-		public void SelectNeighbours(bool select, bool withSameTexture, bool withSameHeight) { } //mxd
+		public void SelectNeighbours(bool select, bool withSameTexture, bool withSameHeight, bool stopatselected) { } //mxd
 	}
 }

--- a/Source/Plugins/BuilderModes/VisualModes/VisualCeiling.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualCeiling.cs
@@ -582,7 +582,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		}
 
 		//mxd
-		public override void SelectNeighbours(bool select, bool withSameTexture, bool withSameHeight) 
+		public override void SelectNeighbours(bool select, bool withSameTexture, bool withSameHeight, bool stopatselected) 
 		{
 			if(!withSameTexture && !withSameHeight) return;
 
@@ -618,7 +618,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 
 							//(de)select regular visual floor?
 							if(select != vs.Floor.Selected) 
-								vs.Floor.SelectNeighbours(select, withSameTexture, withSameHeight);
+								vs.Floor.SelectNeighbours(select, withSameTexture, withSameHeight, stopatselected);
 						}
 					} 
 					else // Regular ceiling or vavoom-type extra ceiling
@@ -631,7 +631,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 
 							//(de)select regular visual ceiling?
 							if(select != vs.Ceiling.Selected) 
-								vs.Ceiling.SelectNeighbours(select, withSameTexture, withSameHeight);
+								vs.Ceiling.SelectNeighbours(select, withSameTexture, withSameHeight, stopatselected);
 						}
 					}
 
@@ -642,7 +642,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 						if((!withSameTexture || level.sector.LongCeilTexture == ec.level.sector.LongCeilTexture) &&
 							(!withSameHeight || level.sector.CeilHeight == ec.level.sector.CeilHeight)) 
 						{
-							ec.SelectNeighbours(select, withSameTexture, withSameHeight);
+							ec.SelectNeighbours(select, withSameTexture, withSameHeight, stopatselected);
 						}
 					}
 
@@ -653,7 +653,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 						if((!withSameTexture || level.sector.LongCeilTexture == ef.Level.sector.LongFloorTexture) &&
 							(!withSameHeight || level.sector.CeilHeight == ef.Level.sector.FloorHeight)) 
 						{
-							ef.SelectNeighbours(select, withSameTexture, withSameHeight);
+							ef.SelectNeighbours(select, withSameTexture, withSameHeight, stopatselected);
 						}
 					}
 				}

--- a/Source/Plugins/BuilderModes/VisualModes/VisualFloor.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualFloor.cs
@@ -507,7 +507,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		}
 
 		//mxd
-		public override void SelectNeighbours(bool select, bool withSameTexture, bool withSameHeight) 
+		public override void SelectNeighbours(bool select, bool withSameTexture, bool withSameHeight, bool stopatselected) 
 		{
 			if(!withSameTexture && !withSameHeight) return;
 
@@ -543,7 +543,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 
 							//(de)select regular visual ceiling?
 							if(select != vs.Ceiling.Selected) 
-								vs.Ceiling.SelectNeighbours(select, withSameTexture, withSameHeight);
+								vs.Ceiling.SelectNeighbours(select, withSameTexture, withSameHeight, stopatselected);
 						}
 					}
 					else // Regular floor or vavoom-type extrafloor
@@ -556,7 +556,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 
 							//(de)select regular visual floor?
 							if(select != vs.Floor.Selected) 
-								vs.Floor.SelectNeighbours(select, withSameTexture, withSameHeight);
+								vs.Floor.SelectNeighbours(select, withSameTexture, withSameHeight, stopatselected);
 						}
 					}
 
@@ -567,7 +567,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 						if((!withSameTexture || level.sector.LongFloorTexture == ef.level.sector.LongFloorTexture) &&
 							(!withSameHeight || level.sector.FloorHeight == ef.level.sector.FloorHeight)) 
 						{
-							ef.SelectNeighbours(select, withSameTexture, withSameHeight);
+							ef.SelectNeighbours(select, withSameTexture, withSameHeight, stopatselected);
 						}
 					}
 
@@ -578,7 +578,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 						if((!withSameTexture || level.sector.LongFloorTexture == ec.Level.sector.LongCeilTexture) &&
 							(!withSameHeight || level.sector.FloorHeight == ec.Level.sector.CeilHeight)) 
 						{
-							ec.SelectNeighbours(select, withSameTexture, withSameHeight);
+							ec.SelectNeighbours(select, withSameTexture, withSameHeight, stopatselected);
 						}
 					}
 				}


### PR DESCRIPTION
Visual Mode: fixed a problem where flood selection would operate from all selected surfaces and not just the clicked on one. This behavior can be reverted by enabling the "Use buggy flood select in Visual Mode" option in Preferences -> Editing